### PR TITLE
chore: establish project metadata baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ the current `0.x` baseline.
 - Established a Keep a Changelog file with an `Unreleased` section.
 - Added MIT licensing documentation for the repository.
 - Documented the pre-MVP SemVer versioning policy in the README.
-- Documented how to run SonarQube Cloud analysis with an explicit token.
+- Documented that SonarQube Cloud analysis requires `SONAR_TOKEN` and an explicit
+  `sonarcloud` Maven profile opt-in.
 
 ### Changed
 
@@ -26,6 +27,9 @@ the current `0.x` baseline.
   pre-MVP development baseline `0.1.0-SNAPSHOT`.
 - Pinned the SonarQube Cloud Maven scanner plugin version to avoid implicit
   scanner version changes during analysis.
+- Configured SonarQube analysis to be skipped by default and enabled only through
+  the `sonarcloud` Maven profile, avoiding unauthenticated scanner failures in
+  pull-request builds.
 
 ## [0.1.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ the current `0.x` baseline.
 - Established a Keep a Changelog file with an `Unreleased` section.
 - Added MIT licensing documentation for the repository.
 - Documented the pre-MVP SemVer versioning policy in the README.
+- Documented how to run SonarQube Cloud analysis with an explicit token.
 
 ### Changed
 
 - Updated Maven coordinates from the placeholder `com:TrafficLightSimulator` at
   `1.0-SNAPSHOT` to `com.trafficlightsimulator:TrafficLightSimulator` at the
   pre-MVP development baseline `0.1.0-SNAPSHOT`.
+- Pinned the SonarQube Cloud Maven scanner plugin version to avoid implicit
+  scanner version changes during analysis.
 
 ## [0.1.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+While the project is pre-MVP, releases use the `0.x.y` SemVer range. Minor
+version increments may include breaking changes until a stable `1.0.0` release
+is declared; patch increments are reserved for backward-compatible fixes within
+the current `0.x` baseline.
+
+## [Unreleased]
+
+### Added
+
+- Established a Keep a Changelog file with an `Unreleased` section.
+- Added MIT licensing documentation for the repository.
+- Documented the pre-MVP SemVer versioning policy in the README.
+
+### Changed
+
+- Updated Maven coordinates from the placeholder `com:TrafficLightSimulator` at
+  `1.0-SNAPSHOT` to `com.trafficlightsimulator:TrafficLightSimulator` at the
+  pre-MVP development baseline `0.1.0-SNAPSHOT`.
+
+## [0.1.0] - 2026-06-04
+
+### Added
+
+- Established the initial pre-MVP SemVer baseline for future project releases.
+
+[Unreleased]: https://github.com/manoj-bhaskaran/TrafficLightSimulator/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/manoj-bhaskaran/TrafficLightSimulator/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ the current `0.x` baseline.
 - Documented the pre-MVP SemVer versioning policy in the README.
 - Documented that SonarQube Cloud analysis requires `SONAR_TOKEN` and an explicit
   `sonarcloud` Maven profile opt-in.
+- Documented how to troubleshoot Maven Central `403 Forbidden` errors while
+  resolving Maven lifecycle plugins.
 
 ### Changed
 
@@ -30,6 +32,7 @@ the current `0.x` baseline.
 - Configured SonarQube analysis to be skipped by default and enabled only through
   the `sonarcloud` Maven profile, avoiding unauthenticated scanner failures in
   pull-request builds.
+- Pinned the Maven resources plugin version used by the verification lifecycle.
 
 ## [0.1.0] - 2026-06-04
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Manoj Bhaskaran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ Run the Maven verification lifecycle from the repository root:
 mvn -B verify
 ```
 
+### Resolving Maven Central 403 errors
+
+If `mvn -B verify` fails while downloading `maven-resources-plugin:3.3.1` with
+`403 Forbidden`, Maven reached the repository but the network, proxy, or mirror
+rejected the request. This repository pins `maven-resources-plugin` to `3.3.1`
+through `maven.resources.plugin.version`, so the failure is environmental rather
+than a missing project version declaration.
+
+To resolve it:
+
+1. Confirm the network can reach Maven Central:
+
+   ```sh
+   curl -I https://repo.maven.apache.org/maven2/
+   ```
+
+2. If you are behind a corporate proxy, configure Maven proxy settings in
+   `~/.m2/settings.xml` or use the approved internal Maven mirror/artifact
+   repository.
+3. If a proxy or mirror outage produced a cached failed download marker, clear the
+   relevant `*.lastUpdated` files from `~/.m2/repository` or rerun Maven with
+   forced updates:
+
+   ```sh
+   mvn -U -B verify
+   ```
+
 ## Static analysis
 
 The Maven build pins the SonarQube Cloud scanner plugin version through the

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Traffic Light Simulator
+
+Traffic Light Simulator is a Java 17 / JavaFX project for modeling traffic light
+simulation domain objects.
+
+## Project metadata
+
+- **Maven group ID:** `com.trafficlightsimulator`
+- **Maven artifact ID:** `TrafficLightSimulator`
+- **Current development version:** `0.1.0-SNAPSHOT`
+- **Java baseline:** Java 17
+
+## Versioning policy
+
+This repository follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Because the project is still pre-MVP, versions remain in the `0.x.y` range until
+a stable `1.0.0` release is ready.
+
+During the pre-MVP phase:
+
+- `0.MINOR.0` releases may introduce breaking changes as the design evolves.
+- `0.x.PATCH` releases are reserved for backward-compatible fixes within the
+  current pre-MVP baseline.
+- Development builds keep the `-SNAPSHOT` qualifier in `pom.xml`.
+
+Notable changes are tracked in [CHANGELOG.md](CHANGELOG.md), using the Keep a
+Changelog format.
+
+## Building and verifying
+
+Run the Maven verification lifecycle from the repository root:
+
+```sh
+mvn -B verify
+```
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for the
+full license text.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Run the Maven verification lifecycle from the repository root:
 mvn -B verify
 ```
 
+## Static analysis
+
+The Maven build pins the SonarQube Cloud scanner plugin version through the
+`sonar.maven.plugin.version` property so CI does not use an implicit, changing
+scanner version. To run SonarQube analysis locally or in CI, provide a valid
+SonarQube Cloud token before invoking the scanner:
+
+```sh
+SONAR_TOKEN=<token> mvn -B sonar:sonar
+```
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for the

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ mvn -B verify
 
 The Maven build pins the SonarQube Cloud scanner plugin version through the
 `sonar.maven.plugin.version` property so CI does not use an implicit, changing
-scanner version. To run SonarQube analysis locally or in CI, provide a valid
-SonarQube Cloud token before invoking the scanner:
+scanner version. Sonar analysis is skipped by default so pull-request builds do
+not fail when `SONAR_TOKEN` is unavailable. Enable analysis explicitly with the
+`sonarcloud` Maven profile and a valid token:
 
 ```sh
-SONAR_TOKEN=<token> mvn -B sonar:sonar
+SONAR_TOKEN=<token> mvn -B -Psonarcloud sonar:sonar
 ```
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <maven.compiler.release>17</maven.compiler.release> <!-- Using Java 17 as it is LTS and compatible -->
         <exec.mainClass>com.trafficlightsimulator.TrafficLightSimulator</exec.mainClass>
         <javafx.version>17.0.2</javafx.version> <!-- Updated to JavaFX 17 for compatibility with Java 17 -->
+        <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
         <sonar.organization>manoj-bhaskaran</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
@@ -37,6 +38,12 @@
 
     <build>
         <plugins>
+            <!-- SonarQube Cloud scanner plugin -->
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar.maven.plugin.version}</version>
+            </plugin>
             <!-- Compiler plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <maven.compiler.release>17</maven.compiler.release> <!-- Using Java 17 as it is LTS and compatible -->
         <exec.mainClass>com.trafficlightsimulator.TrafficLightSimulator</exec.mainClass>
         <javafx.version>17.0.2</javafx.version> <!-- Updated to JavaFX 17 for compatibility with Java 17 -->
+        <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
         <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
         <sonar.skip>true</sonar.skip>
         <sonar.organization>manoj-bhaskaran</sonar.organization>
@@ -47,6 +48,17 @@
     </profiles>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Maven lifecycle plugin versions -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven.resources.plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <!-- SonarQube Cloud scanner plugin -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com</groupId>
+    <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <exec.mainClass>com.trafficlightsimulator.TrafficLightSimulator</exec.mainClass>
         <javafx.version>17.0.2</javafx.version> <!-- Updated to JavaFX 17 for compatibility with Java 17 -->
         <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
+        <sonar.skip>true</sonar.skip>
         <sonar.organization>manoj-bhaskaran</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
@@ -35,6 +36,15 @@
             <classifier>win</classifier>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>sonarcloud</id>
+            <properties>
+                <sonar.skip>false</sonar.skip>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>


### PR DESCRIPTION
### Motivation

- Standardize Maven coordinates and establish a SemVer baseline for pre-MVP development. 
- Provide repository-level metadata, a license, and a changelog so releases and contributions are clearer. 

### Description

- Updated `pom.xml` groupId from the placeholder `com` to `com.trafficlightsimulator` and set the development version to `0.1.0-SNAPSHOT` to establish a SemVer baseline. 
- Added `CHANGELOG.md` using the Keep a Changelog format with an `Unreleased` section and an initial `0.1.0` entry. 
- Added an `MIT` `LICENSE` file and a `README.md` documenting project metadata, versioning policy, build instructions, and license. 

### Testing

- Verified `pom.xml` is well-formed XML using `python - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('pom.xml')\nprint('pom.xml is well-formed XML')\nPY` which succeeded. 
- Attempted `mvn -B verify`, which ran but failed during plugin resolution because Maven Central returned a `403 Forbidden` while resolving `maven-resources-plugin:3.3.1`, so the full Maven verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21647ee49083258a97020ff9fa86fa)