### PR TITLE
feat: add runnable application entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the current `0.x` baseline.
 
 ### Added
 
+- Added a runnable application entry point that bootstraps and logs a sample
+  traffic-light intersection.
+- Added executable jar manifest configuration so packaged artifacts can be run
+  with `java -jar`.
+- Documented Maven and packaged-jar application run commands in the README.
 - Established a Keep a Changelog file with an `Unreleased` section.
 - Added MIT licensing documentation for the repository.
 - Documented the pre-MVP SemVer versioning policy in the README.
@@ -24,6 +29,8 @@ the current `0.x` baseline.
 
 ### Changed
 
+- Incremented the pre-MVP development version from `0.1.0-SNAPSHOT` to
+  `0.1.1-SNAPSHOT` for the runnable packaging fix.
 - Updated Maven coordinates from the placeholder `com:TrafficLightSimulator` at
   `1.0-SNAPSHOT` to `com.trafficlightsimulator:TrafficLightSimulator` at the
   pre-MVP development baseline `0.1.0-SNAPSHOT`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simulation domain objects.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.1.0-SNAPSHOT`
+- **Current development version:** `0.1.1-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -32,6 +32,21 @@ Run the Maven verification lifecycle from the repository root:
 
 ```sh
 mvn -B verify
+```
+
+## Running the application
+
+Run the simulator entry point directly with Maven:
+
+```sh
+mvn exec:java
+```
+
+Build the executable jar package, then launch it with `java -jar`:
+
+```sh
+mvn -B package
+java -jar target/TrafficLightSimulator-0.1.1-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>
@@ -75,6 +75,20 @@
                     <compilerArgs>
                         <arg>-Xlint</arg>
                     </compilerArgs>
+                </configuration>
+            </plugin>
+
+            <!-- Jar plugin for executable application packaging -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${exec.mainClass}</mainClass>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
             <!-- JavaFX plugin for running JavaFX applications -->

--- a/src/main/java/com/trafficlightsimulator/TrafficLightSimulator.java
+++ b/src/main/java/com/trafficlightsimulator/TrafficLightSimulator.java
@@ -1,0 +1,58 @@
+package com.trafficlightsimulator;
+
+import com.trafficlightsimulator.model.Color;
+import com.trafficlightsimulator.model.Direction;
+import com.trafficlightsimulator.model.Intersection;
+import com.trafficlightsimulator.model.Road;
+import com.trafficlightsimulator.model.State;
+import com.trafficlightsimulator.model.TrafficLight;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Application entry point for the Traffic Light Simulator.
+ */
+public final class TrafficLightSimulator {
+    private static final Logger logger = Logger.getLogger(TrafficLightSimulator.class.getName());
+
+    private TrafficLightSimulator() {
+        // Utility class: prevent instantiation.
+    }
+
+    /**
+     * Bootstraps a minimal sample intersection so the packaged application can be run.
+     *
+     * @param args command-line arguments; currently unused
+     */
+    public static void main(String[] args) {
+        Intersection intersection = createSampleIntersection();
+        intersection.initializeTrafficLightGroups();
+
+        logger.log(Level.INFO, "Traffic Light Simulator started with {0} roads and {1} total lanes.",
+                new Object[]{intersection.getRoads().size(), intersection.getAllLanes().size()});
+        intersection.displayIntersectionStatus();
+    }
+
+    private static Intersection createSampleIntersection() {
+        Intersection intersection = new Intersection(2);
+        Road northboundRoad = createRoad(0.0, Color.GREEN, Direction.STRAIGHT);
+        Road eastboundRoad = createRoad(90.0, Color.RED, Direction.LEFT);
+
+        intersection.addRoad(northboundRoad);
+        intersection.addRoad(eastboundRoad);
+
+        return intersection;
+    }
+
+    private static Road createRoad(double angle, Color initialColor, Direction direction) {
+        Road road = new Road(angle, 1, 1);
+        road.addTrafficLightToIncomingGroup(new TrafficLight(
+                initialColor,
+                State.ON,
+                TrafficLight.Type.TRAFFIC,
+                direction,
+                true));
+        return road;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple application entry point so the project can be executed and smoke-tested locally. 
- Produce an executable JAR by writing a `Main-Class` manifest entry so consumers can run the package with `java -jar`.
- Bump the pre-MVP development version and document how to run the application in repository docs.

### Description

- Added `src/main/java/com/trafficlightsimulator/TrafficLightSimulator.java` which bootstraps a minimal two-road `Intersection`, initializes traffic-light groups, and logs state on startup. 
- Configured the Maven build to produce an executable jar by adding `maven-jar-plugin` with `mainClass` set to `${exec.mainClass}` and ensured `exec.mainClass` points at the new entrypoint. 
- Bumped the project version in `pom.xml` from `0.1.0-SNAPSHOT` to `0.1.1-SNAPSHOT`. 
- Updated `README.md` with `mvn exec:java` and `java -jar target/TrafficLightSimulator-0.1.1-SNAPSHOT.jar` run instructions and recorded the changes in `CHANGELOG.md`.

### Testing

- Compiled and ran the project classes directly with `javac --release 17 -d /tmp/tls-classes $(find src/main/java -name '*.java') && java -cp /tmp/tls-classes com.trafficlightsimulator.TrafficLightSimulator`, and the sample intersection boot sequence executed successfully. 
- Ran `git diff --check` to validate whitespace/patch issues and it returned clean. 
- Attempted `mvn -B package` but the build failed due to the environment returning HTTP 403 when resolving Maven Central plugins (plugin resolution failure). 
- Attempted `mvn exec:java` but it likewise failed due to Maven Central returning HTTP 403 while resolving required plugins in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216c09fa008325935a7042d1ab467e)