### PR TITLE
fix(build): remove platform-locked JavaFX dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ the current `0.x` baseline.
 
 ### Changed
 
+- Incremented the pre-MVP development version from `0.1.1-SNAPSHOT` to
+  `0.1.2-SNAPSHOT` for the platform-portable dependency fix.
+- Removed unused JavaFX dependencies, including the Windows-only
+  `javafx-graphics` classifier, so Maven verification resolves dependencies
+  portably on Linux, macOS, and Windows.
+- Updated the README to describe the current Java-only runtime dependency
+  baseline and the deferred JavaFX GUI dependency policy.
 - Incremented the pre-MVP development version from `0.1.0-SNAPSHOT` to
   `0.1.1-SNAPSHOT` for the runnable packaging fix.
 - Updated Maven coordinates from the placeholder `com:TrafficLightSimulator` at

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Traffic Light Simulator
 
-Traffic Light Simulator is a Java 17 / JavaFX project for modeling traffic light
+Traffic Light Simulator is a Java 17 project for modeling traffic light
 simulation domain objects.
 
 ## Project metadata
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.1.1-SNAPSHOT`
+- **Current development version:** `0.1.2-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -46,7 +46,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.1.1-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.1.2-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors
@@ -75,6 +75,12 @@ To resolve it:
    ```sh
    mvn -U -B verify
    ```
+
+## Dependency notes
+
+The current simulator entry point uses only standard Java APIs. JavaFX dependencies
+are intentionally not declared until a GUI is added, which keeps Maven dependency
+resolution portable across Linux, macOS, and Windows.
 
 ## Static analysis
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release> <!-- Using Java 17 as it is LTS and compatible -->
         <exec.mainClass>com.trafficlightsimulator.TrafficLightSimulator</exec.mainClass>
-        <javafx.version>17.0.2</javafx.version> <!-- Updated to JavaFX 17 for compatibility with Java 17 -->
         <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
         <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
         <sonar.skip>true</sonar.skip>
@@ -18,26 +17,6 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
     
-    <dependencies>
-        <!-- JavaFX dependencies -->
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
-            <version>${javafx.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-fxml</artifactId>
-            <version>${javafx.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-graphics</artifactId>
-            <version>${javafx.version}</version>
-            <classifier>win</classifier>
-        </dependency>
-    </dependencies>
-
     <profiles>
         <profile>
             <id>sonarcloud</id>
@@ -91,7 +70,7 @@
                     </archive>
                 </configuration>
             </plugin>
-            <!-- JavaFX plugin for running JavaFX applications -->
+            <!-- Exec plugin for running the application entry point -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
### Motivation

- The build declared JavaFX artifacts (including a Windows-only `javafx-graphics` classifier) and a `javafx.version` property which made Maven dependency resolution platform-locked and caused portability issues across CI and developer environments. 
- The change aims to keep the current runnable entry point on standard Java APIs and defer JavaFX GUI dependencies until a cross-platform GUI is added, while recording a patch version bump per the pre-MVP SemVer policy.

### Description

- Removed the `javafx.version` property and all `org.openjfx` JavaFX dependencies (including the platform `classifier`) from `pom.xml` so the project only depends on standard Java at build time.  
- Bumped the development version from `0.1.1-SNAPSHOT` to `0.1.2-SNAPSHOT` in `pom.xml` and updated the README references to the new snapshot artifact name.  
- Added a `Dependency notes` section to `README.md` documenting the deferred JavaFX GUI dependency policy and portability rationale.  
- Updated `CHANGELOG.md` Unreleased notes to document the dependency removal, version bump, and README updates, and adjusted a comment in the POM to refer to the exec plugin for running the entry point.

### Testing

- Verified `pom.xml` is well-formed with `ET.parse('pom.xml')`, which succeeded.  
- Searched for remaining JavaFX/platform-locked markers with `rg` to confirm removals, which succeeded.  
- Attempted `mvn -B verify`, which failed in this environment due to Maven Central returning `403 Forbidden` for the lifecycle plugin download.  
- Attempted `mvn -o -B verify` in offline mode, which failed because the required plugin was not cached locally.  
- Compiled and ran the application directly with `javac --release 17` and `java -cp ... com.trafficlightsimulator.TrafficLightSimulator`, which succeeded and produced the expected runtime logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216e6217608325b1d1bffca5468760)