### PR TITLE
feat: add traffic light incompatibility rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ the current `0.x` baseline.
 
 ### Added
 
+- Added traffic-light incompatibility rules to `TrafficLightGroup`, including
+  symmetric configuration, removal, lookup, and guarded per-light color/state
+  updates that reject incompatible simultaneous `GREEN`/`ON` signals with clear
+  feedback.
+- Added `Intersection.configureIncompatibleTrafficLights` to register
+  incompatibility rules across the road and pedestrian light groups that belong
+  to an intersection.
+- Added unit tests covering incompatibility configuration, conflict prevention,
+  inactive-light allowance, group membership validation, and cross-road
+  intersection enforcement.
 - Added JUnit Jupiter 5.11 as a test-scoped dependency and configured
   `maven-surefire-plugin` 3.3.1 to run JUnit 5 tests.
 - Added `TrafficLightTest` covering `setColor` for all combinations of
@@ -29,6 +39,11 @@ the current `0.x` baseline.
   `IllegalArgumentException` with a clear message.
 
 ### Changed
+
+- Incremented the pre-MVP development version from `0.2.0-SNAPSHOT` to
+  `0.3.0-SNAPSHOT` for the traffic-light incompatibility feature.
+- Documented traffic-light safety rule configuration and enforcement in the
+  README.
 
 - Deleted the top-level `Type.java` enum (`TRAFFIC`, `PEDESTRIAN`), which was
   dead code. The canonical definition is the nested `TrafficLight.Type` enum,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simulation domain objects.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.1.2-SNAPSHOT`
+- **Current development version:** `0.3.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -46,7 +46,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.1.2-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.3.0-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors
@@ -75,6 +75,21 @@ To resolve it:
    ```sh
    mvn -U -B verify
    ```
+
+
+## Traffic-light safety rules
+
+`TrafficLightGroup` can define incompatible traffic-light pairs that must never
+show active, conflicting signals at the same time. In this model, a light is
+considered active when it is `GREEN` and `ON`. Use `addIncompatibleLights` to
+configure a pair and update managed lights through `setLightColor` or
+`setLightState` so the group can reject unsafe activation attempts with a clear
+`IllegalStateException`.
+
+For lights controlled by different road or pedestrian groups in an
+`Intersection`, call `configureIncompatibleTrafficLights`. The intersection
+locates the owning groups and registers the incompatibility in each affected
+group, so either group prevents simultaneous conflicting green signals.
 
 ## Dependency notes
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -66,6 +66,41 @@ public class Intersection {
         return pedestrianCrossings;
     }
 
+    // Method to configure two traffic lights in this intersection as mutually incompatible
+    public void configureIncompatibleTrafficLights(TrafficLight firstLight, TrafficLight secondLight) {
+        TrafficLightGroup firstGroup = findTrafficLightGroup(firstLight);
+        TrafficLightGroup secondGroup = findTrafficLightGroup(secondLight);
+
+        if (firstGroup == null || secondGroup == null) {
+            throw new IllegalArgumentException("Both traffic lights must belong to this intersection before incompatibilities can be configured.");
+        }
+
+        firstGroup.addIncompatibleLights(firstLight, secondLight);
+        if (secondGroup != firstGroup) {
+            secondGroup.addIncompatibleLights(secondLight, firstLight);
+        }
+        logger.log(Level.INFO, "Configured incompatible traffic lights for intersection: {0} <-> {1}",
+                new Object[]{firstLight, secondLight});
+    }
+
+    // Method to retrieve all traffic light groups in the intersection
+    public List<TrafficLightGroup> getAllTrafficLightGroups() {
+        List<TrafficLightGroup> trafficLightGroups = new ArrayList<>();
+        for (Road road : roads) {
+            TrafficLightGroup trafficLightGroup = road.getIncomingLanesTrafficLightGroup();
+            if (trafficLightGroup != null) {
+                trafficLightGroups.add(trafficLightGroup);
+            }
+            if (road.hasPedestrianCrossing()) {
+                TrafficLightGroup pedestrianLightGroup = road.getPedestrianCrossing().getPedestrianLightGroup();
+                if (pedestrianLightGroup != null) {
+                    trafficLightGroups.add(pedestrianLightGroup);
+                }
+            }
+        }
+        return trafficLightGroups;
+    }
+
     // Method to initialize all traffic light groups in the intersection
     public void initializeTrafficLightGroups() {
         for (Road road : roads) {
@@ -86,6 +121,18 @@ public class Intersection {
                 logger.log(Level.INFO, "Initialized pedestrian light group for crossing: {0}", crossing);
             }
         }
+    }
+
+    private TrafficLightGroup findTrafficLightGroup(TrafficLight light) {
+        if (light == null) {
+            throw new IllegalArgumentException("Traffic light must not be null.");
+        }
+        for (TrafficLightGroup trafficLightGroup : getAllTrafficLightGroups()) {
+            if (trafficLightGroup.getLights().contains(light)) {
+                return trafficLightGroup;
+            }
+        }
+        return null;
     }
 
     // Method to check if the intersection setup is complete

--- a/src/main/java/com/trafficlightsimulator/model/TrafficLight.java
+++ b/src/main/java/com/trafficlightsimulator/model/TrafficLight.java
@@ -1,6 +1,10 @@
 package com.trafficlightsimulator.model;
 
-// TrafficLight class
+/**
+ * Traffic-light domain object. Instances intentionally use Java object identity
+ * for equality so {@link TrafficLightGroup} incompatibility rules can target
+ * specific physical lights.
+ */
 public class TrafficLight {
     
      public enum Type {

--- a/src/main/java/com/trafficlightsimulator/model/TrafficLightGroup.java
+++ b/src/main/java/com/trafficlightsimulator/model/TrafficLightGroup.java
@@ -1,23 +1,30 @@
 package com.trafficlightsimulator.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class TrafficLightGroup {
     private static final Logger logger = Logger.getLogger(TrafficLightGroup.class.getName());
-    private List<TrafficLight> lights;
+    private final List<TrafficLight> lights;
+    private final Map<TrafficLight, Set<TrafficLight>> incompatibleLights;
 
     // Constructor
     public TrafficLightGroup() {
         this.lights = new ArrayList<>();
+        this.incompatibleLights = new IdentityHashMap<>();
     }
 
     // Method to add a traffic light to the group
     public void addTrafficLight(TrafficLight light) {
         if (light != null) {
             lights.add(light);
+            incompatibleLights.computeIfAbsent(light, ignored -> newIdentitySet());
             logger.log(Level.INFO, "Traffic light added: {0}", light);
         }
     }
@@ -25,16 +32,71 @@ public class TrafficLightGroup {
     // Method to remove a traffic light from the group
     public void removeTrafficLight(TrafficLight light) {
         lights.remove(light);
+        incompatibleLights.remove(light);
+        for (Set<TrafficLight> incompatibleSet : incompatibleLights.values()) {
+            incompatibleSet.remove(light);
+        }
         logger.log(Level.INFO, "Traffic light removed: {0}", light);
+    }
+
+    // Method to configure two lights that cannot be active at the same time
+    public void addIncompatibleLights(TrafficLight firstLight, TrafficLight secondLight) {
+        validateIncompatibilityPair(firstLight, secondLight);
+        incompatibleLights.computeIfAbsent(firstLight, ignored -> newIdentitySet()).add(secondLight);
+        incompatibleLights.computeIfAbsent(secondLight, ignored -> newIdentitySet()).add(firstLight);
+        logger.log(Level.INFO, "Configured incompatible lights: {0} <-> {1}",
+                new Object[]{firstLight, secondLight});
+    }
+
+    // Method to remove a configured incompatibility between two lights
+    public void removeIncompatibleLights(TrafficLight firstLight, TrafficLight secondLight) {
+        if (firstLight == null || secondLight == null) {
+            throw new IllegalArgumentException("Incompatible lights must not be null.");
+        }
+        removeIncompatibility(firstLight, secondLight);
+        removeIncompatibility(secondLight, firstLight);
+        logger.log(Level.INFO, "Removed incompatible lights: {0} <-> {1}",
+                new Object[]{firstLight, secondLight});
+    }
+
+    // Method to check if two lights have been configured as incompatible
+    public boolean areIncompatible(TrafficLight firstLight, TrafficLight secondLight) {
+        if (firstLight == null || secondLight == null) {
+            return false;
+        }
+        return incompatibleLights.getOrDefault(firstLight, Collections.emptySet()).contains(secondLight);
+    }
+
+    // Method to retrieve lights that are incompatible with the given light
+    public Set<TrafficLight> getIncompatibleLights(TrafficLight light) {
+        if (light == null) {
+            throw new IllegalArgumentException("Traffic light must not be null.");
+        }
+        return Collections.unmodifiableSet(incompatibleLights.getOrDefault(light, Collections.emptySet()));
+    }
+
+    // Method to set one light to a specified color with safety checks
+    public void setLightColor(TrafficLight light, Color color) {
+        validateManagedLight(light);
+        ensureCompatibleActivation(light, color, light.getState());
+        light.setColor(color);
+        logger.log(Level.INFO, "Set color {0} for light: {1}", new Object[]{color, light});
+    }
+
+    // Method to set one light to a specified state with safety checks
+    public void setLightState(TrafficLight light, State state) {
+        validateManagedLight(light);
+        ensureCompatibleActivation(light, light.getColor(), state);
+        light.setState(state);
+        logger.log(Level.INFO, "Set state {0} for light: {1}", new Object[]{state, light});
     }
 
     // Method to set all lights in the group to a specified color (if they support color change)
     public void setAllLightsColor(Color color) {
         for (TrafficLight light : lights) {
             try {
-                light.setColor(color);
-                logger.log(Level.INFO, "Set color {0} for light: {1}", new Object[]{color, light});
-            } catch (IllegalArgumentException e) {
+                setLightColor(light, color);
+            } catch (IllegalArgumentException | IllegalStateException e) {
                 logger.log(Level.WARNING, "Cannot set color for light: {0}", e.getMessage());
             }
         }
@@ -43,8 +105,11 @@ public class TrafficLightGroup {
     // Method to set all lights in the group to a specified state
     public void setAllLightsState(State state) {
         for (TrafficLight light : lights) {
-            light.setState(state);
-            logger.log(Level.INFO, "Set state {0} for light: {1}", new Object[]{state, light});
+            try {
+                setLightState(light, state);
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                logger.log(Level.WARNING, "Cannot set state for light: {0}", e.getMessage());
+            }
         }
     }
 
@@ -56,8 +121,64 @@ public class TrafficLightGroup {
     // Method to display the current state of each light in the group (for debugging)
     public void displayGroupStatus() {
         for (TrafficLight light : lights) {
-            logger.log(Level.INFO, "Light Type: {0}, Color: {1}, State: {2}", 
+            logger.log(Level.INFO, "Light Type: {0}, Color: {1}, State: {2}",
                        new Object[]{light.getType(), light.getColor(), light.getState()});
+        }
+    }
+
+    private void validateIncompatibilityPair(TrafficLight firstLight, TrafficLight secondLight) {
+        if (firstLight == null || secondLight == null) {
+            throw new IllegalArgumentException("Incompatible lights must not be null.");
+        }
+        if (firstLight == secondLight) {
+            throw new IllegalArgumentException("A traffic light cannot be incompatible with itself.");
+        }
+    }
+
+    private void validateManagedLight(TrafficLight light) {
+        if (light == null) {
+            throw new IllegalArgumentException("Traffic light must not be null.");
+        }
+        if (!lights.contains(light)) {
+            throw new IllegalArgumentException("Traffic light must belong to this group before it can be changed.");
+        }
+    }
+
+    private void ensureCompatibleActivation(TrafficLight light, Color candidateColor, State candidateState) {
+        if (!isActive(candidateColor, candidateState)) {
+            return;
+        }
+
+        for (TrafficLight incompatibleLight : incompatibleLights.getOrDefault(light, Collections.emptySet())) {
+            if (isActive(incompatibleLight)) {
+                throw new IllegalStateException("Cannot activate " + describe(light)
+                        + " because incompatible light " + describe(incompatibleLight)
+                        + " is already active.");
+            }
+        }
+    }
+
+    private boolean isActive(TrafficLight light) {
+        return light != null && isActive(light.getColor(), light.getState());
+    }
+
+    private boolean isActive(Color color, State state) {
+        return color == Color.GREEN && state == State.ON;
+    }
+
+    private String describe(TrafficLight light) {
+        return light.getType() + " light facing " + light.getDirection()
+                + " with color " + light.getColor() + " and state " + light.getState();
+    }
+
+    private Set<TrafficLight> newIdentitySet() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+
+    private void removeIncompatibility(TrafficLight firstLight, TrafficLight secondLight) {
+        Set<TrafficLight> incompatibleSet = incompatibleLights.get(firstLight);
+        if (incompatibleSet != null) {
+            incompatibleSet.remove(secondLight);
         }
     }
 }

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -1,0 +1,31 @@
+package com.trafficlightsimulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IntersectionTest {
+
+    @Test
+    void configureIncompatibleTrafficLights_enforcesConflictsAcrossRoadGroups() {
+        Intersection intersection = new Intersection(2);
+        Road northRoad = new Road(0.0, 1, 1);
+        Road eastRoad = new Road(90.0, 1, 1);
+        TrafficLight northLight = trafficLight(Direction.STRAIGHT, Color.GREEN, State.ON);
+        TrafficLight eastLight = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        northRoad.addTrafficLightToIncomingGroup(northLight);
+        eastRoad.addTrafficLightToIncomingGroup(eastLight);
+        intersection.addRoad(northRoad);
+        intersection.addRoad(eastRoad);
+
+        intersection.configureIncompatibleTrafficLights(northLight, eastLight);
+
+        assertThrows(IllegalStateException.class,
+                () -> eastRoad.getIncomingLanesTrafficLightGroup().setLightColor(eastLight, Color.GREEN));
+        assertEquals(Color.RED, eastLight.getColor());
+    }
+
+    private TrafficLight trafficLight(Direction direction, Color color, State state) {
+        return new TrafficLight(color, state, TrafficLight.Type.TRAFFIC, direction, true);
+    }
+}

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
@@ -1,0 +1,82 @@
+package com.trafficlightsimulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TrafficLightGroupTest {
+
+    @Test
+    void addIncompatibleLights_configuresSymmetricIdentityRelationship() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight northbound = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+        TrafficLight eastbound = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        group.addTrafficLight(northbound);
+        group.addTrafficLight(eastbound);
+
+        group.addIncompatibleLights(northbound, eastbound);
+
+        assertTrue(group.areIncompatible(northbound, eastbound));
+        assertTrue(group.areIncompatible(eastbound, northbound));
+        assertEquals(Set.of(eastbound), group.getIncompatibleLights(northbound));
+    }
+
+    @Test
+    void setLightColor_preventsGreenWhenIncompatibleLightAlreadyActive() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight active = trafficLight(Direction.STRAIGHT, Color.GREEN, State.ON);
+        TrafficLight conflicting = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        group.addTrafficLight(active);
+        group.addTrafficLight(conflicting);
+        group.addIncompatibleLights(active, conflicting);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> group.setLightColor(conflicting, Color.GREEN));
+
+        assertTrue(exception.getMessage().contains("Cannot activate"));
+        assertTrue(exception.getMessage().contains("already active"));
+        assertEquals(Color.RED, conflicting.getColor());
+    }
+
+    @Test
+    void setLightState_preventsOnWhenIncompatibleGreenLightAlreadyActive() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight active = trafficLight(Direction.STRAIGHT, Color.GREEN, State.ON);
+        TrafficLight conflicting = trafficLight(Direction.RIGHT, Color.GREEN, State.OFF);
+        group.addTrafficLight(active);
+        group.addTrafficLight(conflicting);
+        group.addIncompatibleLights(active, conflicting);
+
+        assertThrows(IllegalStateException.class, () -> group.setLightState(conflicting, State.ON));
+
+        assertEquals(State.OFF, conflicting.getState());
+    }
+
+    @Test
+    void setLightColor_allowsGreenWhenIncompatibleLightIsNotActive() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight inactive = trafficLight(Direction.STRAIGHT, Color.GREEN, State.OFF);
+        TrafficLight candidate = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        group.addTrafficLight(inactive);
+        group.addTrafficLight(candidate);
+        group.addIncompatibleLights(inactive, candidate);
+
+        group.setLightColor(candidate, Color.GREEN);
+
+        assertEquals(Color.GREEN, candidate.getColor());
+    }
+
+    @Test
+    void setLightColor_requiresLightToBelongToGroup() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight ungrouped = trafficLight(Direction.NONE, Color.RED, State.ON);
+
+        assertThrows(IllegalArgumentException.class, () -> group.setLightColor(ungrouped, Color.GREEN));
+    }
+
+    private TrafficLight trafficLight(Direction direction, Color color, State state) {
+        return new TrafficLight(color, state, TrafficLight.Type.TRAFFIC, direction, true);
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent simultaneous conflicting signals by allowing the simulator to declare specific traffic lights as mutually incompatible so the system can reject unsafe activations.

### Description

- Added identity-based incompatibility tracking to `TrafficLightGroup` with `addIncompatibleLights`, `removeIncompatibleLights`, `areIncompatible`, and `getIncompatibleLights`, and maintained cleanup when lights are removed.
- Added guarded per-light update APIs `setLightColor` and `setLightState` to `TrafficLightGroup` and routed existing group-wide setters through these guards so the group rejects activation attempts that would produce simultaneous active conflicting signals (active = `GREEN` + `ON`).
- Added intersection-level helpers `Intersection.configureIncompatibleTrafficLights`, `getAllTrafficLightGroups`, and `findTrafficLightGroup` so incompatibilities can be registered across road and pedestrian groups that belong to an `Intersection`.
- Documented identity semantics for `TrafficLight` instances and added README documentation explaining the traffic-light safety rules and how to configure them.
- Bumped development version to `0.3.0-SNAPSHOT` and updated `CHANGELOG.md` with the new feature and tests.
- Added unit tests `TrafficLightGroupTest` and `IntersectionTest` covering symmetric registration, conflict prevention, membership validation, inactive-light allowance, and cross-group enforcement.

### Testing

- Successfully compiled all Java sources with `javac -d /tmp/tls-classes $(find src/main/java -name '*.java' -print)`.
- Attempted to run `mvn -B test`, but the Maven execution was blocked by an external environment error resolving `maven-resources-plugin:3.3.1` (HTTP 403 from Maven Central) so the test lifecycle could not complete.
- New unit tests were added to the test suite (`TrafficLightGroupTest`, `IntersectionTest`) and are ready to run once the Maven environment can resolve plugins.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2172f5d5d08325a61ea0261f74fc29)