### PR TITLE
test: add JaCoCo coverage reporting and unit tests (bump to 0.4.0-SNAPSHOT)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=manoj-bhaskaran_TrafficLightSimulator
+        run: mvn -B -Psonarcloud verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=manoj-bhaskaran_TrafficLightSimulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the current `0.x` baseline.
 
 ### Added
 
+- Added JaCoCo coverage instrumentation and XML report generation during
+  `mvn verify`, plus SonarQube Cloud coverage report path wiring for CI
+  analysis.
+- Added validation tests for `Intersection` road-count bounds and add-road
+  capacity, plus `Road` angle bounds tests.
 - Added traffic-light incompatibility rules to `TrafficLightGroup`, including
   symmetric configuration, removal, lookup, and guarded per-light color/state
   updates that reject incompatible simultaneous `GREEN`/`ON` signals with clear
@@ -40,6 +45,11 @@ the current `0.x` baseline.
 
 ### Changed
 
+- Incremented the pre-MVP development version from `0.3.0-SNAPSHOT` to
+  `0.4.0-SNAPSHOT` for the automated testing and coverage framework.
+- Updated CI to run SonarQube Cloud analysis with the `sonarcloud` profile so
+  scanner execution imports the generated JaCoCo XML coverage report.
+- Documented the automated test and coverage workflow in the README.
 - Incremented the pre-MVP development version from `0.2.0-SNAPSHOT` to
   `0.3.0-SNAPSHOT` for the traffic-light incompatibility feature.
 - Documented traffic-light safety rule configuration and enforcement in the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simulation domain objects.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.3.0-SNAPSHOT`
+- **Current development version:** `0.4.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -34,6 +34,20 @@ Run the Maven verification lifecycle from the repository root:
 mvn -B verify
 ```
 
+## Automated tests and coverage
+
+The repository uses JUnit Jupiter for unit tests, Maven Surefire to run tests in
+the standard Maven lifecycle, and JaCoCo to generate coverage. Run the full
+verification lifecycle to compile the project, execute tests, and write the XML
+coverage report consumed by SonarQube Cloud:
+
+```sh
+mvn -B verify
+```
+
+The JaCoCo XML report is generated at
+`target/site/jacoco/jacoco.xml`.
+
 ## Running the application
 
 Run the simulator entry point directly with Maven:
@@ -46,7 +60,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.3.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.4.0-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors
@@ -101,12 +115,15 @@ resolution portable across Linux, macOS, and Windows.
 
 The Maven build pins the SonarQube Cloud scanner plugin version through the
 `sonar.maven.plugin.version` property so CI does not use an implicit, changing
-scanner version. Sonar analysis is skipped by default so pull-request builds do
-not fail when `SONAR_TOKEN` is unavailable. Enable analysis explicitly with the
-`sonarcloud` Maven profile and a valid token:
+scanner version. The build also sets
+`sonar.coverage.jacoco.xmlReportPaths` to `target/site/jacoco/jacoco.xml`, so
+SonarQube Cloud imports JaCoCo coverage produced during `mvn verify`. Sonar
+analysis is skipped by default so pull-request builds do not fail when
+`SONAR_TOKEN` is unavailable. Enable analysis explicitly with the `sonarcloud`
+Maven profile and a valid token:
 
 ```sh
-SONAR_TOKEN=<token> mvn -B -Psonarcloud sonar:sonar
+SONAR_TOKEN=<token> mvn -B -Psonarcloud verify sonar:sonar
 ```
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>
@@ -11,10 +11,14 @@
         <maven.compiler.release>17</maven.compiler.release> <!-- Using Java 17 as it is LTS and compatible -->
         <exec.mainClass>com.trafficlightsimulator.TrafficLightSimulator</exec.mainClass>
         <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
+        <junit.jupiter.version>5.11.0</junit.jupiter.version>
+        <maven.surefire.plugin.version>3.3.1</maven.surefire.plugin.version>
+        <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
         <sonar.skip>true</sonar.skip>
         <sonar.organization>manoj-bhaskaran</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
     
     <profiles>
@@ -30,7 +34,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.0</version>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -83,7 +87,31 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+            <!-- JaCoCo plugin for XML coverage consumed by SonarQube Cloud -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Exec plugin for running the application entry point -->
             <plugin>

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -1,6 +1,7 @@
 package com.trafficlightsimulator.model;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,8 +43,9 @@ class IntersectionTest {
         intersection.addRoad(new Road(90.0, 1, 1));
         Road extraRoad = new Road(180.0, 1, 1);
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> intersection.addRoad(extraRoad));
+        Executable addExtraRoad = () -> intersection.addRoad(extraRoad);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, addExtraRoad);
 
         assertTrue(exception.getMessage().contains("Cannot add more roads"));
         assertEquals(2, intersection.getRoads().size());
@@ -65,8 +67,9 @@ class IntersectionTest {
 
         TrafficLightGroup eastLightGroup = eastRoad.getIncomingLanesTrafficLightGroup();
 
-        assertThrows(IllegalStateException.class,
-                () -> eastLightGroup.setLightColor(eastLight, Color.GREEN));
+        Executable activateEastLight = () -> eastLightGroup.setLightColor(eastLight, Color.GREEN);
+
+        assertThrows(IllegalStateException.class, activateEastLight);
         assertEquals(Color.RED, eastLight.getColor());
     }
 

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -7,6 +7,48 @@ import static org.junit.jupiter.api.Assertions.*;
 class IntersectionTest {
 
     @Test
+    void constructor_acceptsMinimumAndMaximumRoadCounts() {
+        assertEquals(0, new Intersection(2).getRoads().size());
+        assertEquals(0, new Intersection(8).getRoads().size());
+    }
+
+    @Test
+    void constructor_rejectsRoadCountBelowMinimum() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new Intersection(1));
+
+        assertTrue(exception.getMessage().contains("between 2 and 8"));
+    }
+
+    @Test
+    void constructor_rejectsRoadCountAboveMaximum() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new Intersection(9));
+
+        assertTrue(exception.getMessage().contains("between 2 and 8"));
+    }
+
+    @Test
+    void addRoad_rejectsNullRoad() {
+        Intersection intersection = new Intersection(2);
+
+        assertThrows(IllegalArgumentException.class, () -> intersection.addRoad(null));
+    }
+
+    @Test
+    void addRoad_rejectsRoadsBeyondConfiguredCapacity() {
+        Intersection intersection = new Intersection(2);
+        intersection.addRoad(new Road(0.0, 1, 1));
+        intersection.addRoad(new Road(90.0, 1, 1));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> intersection.addRoad(new Road(180.0, 1, 1)));
+
+        assertTrue(exception.getMessage().contains("Cannot add more roads"));
+        assertEquals(2, intersection.getRoads().size());
+    }
+
+    @Test
     void configureIncompatibleTrafficLights_enforcesConflictsAcrossRoadGroups() {
         Intersection intersection = new Intersection(2);
         Road northRoad = new Road(0.0, 1, 1);

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -40,9 +40,10 @@ class IntersectionTest {
         Intersection intersection = new Intersection(2);
         intersection.addRoad(new Road(0.0, 1, 1));
         intersection.addRoad(new Road(90.0, 1, 1));
+        Road extraRoad = new Road(180.0, 1, 1);
 
         IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> intersection.addRoad(new Road(180.0, 1, 1)));
+                () -> intersection.addRoad(extraRoad));
 
         assertTrue(exception.getMessage().contains("Cannot add more roads"));
         assertEquals(2, intersection.getRoads().size());
@@ -62,8 +63,10 @@ class IntersectionTest {
 
         intersection.configureIncompatibleTrafficLights(northLight, eastLight);
 
+        TrafficLightGroup eastLightGroup = eastRoad.getIncomingLanesTrafficLightGroup();
+
         assertThrows(IllegalStateException.class,
-                () -> eastRoad.getIncomingLanesTrafficLightGroup().setLightColor(eastLight, Color.GREEN));
+                () -> eastLightGroup.setLightColor(eastLight, Color.GREEN));
         assertEquals(Color.RED, eastLight.getColor());
     }
 

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -1,0 +1,65 @@
+package com.trafficlightsimulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RoadTest {
+
+    @Test
+    void constructor_acceptsMinimumAngle() {
+        Road road = new Road(0.0, 1, 1);
+
+        assertEquals(0.0, road.getAngle());
+    }
+
+    @Test
+    void constructor_acceptsAngleBelowFullCircle() {
+        Road road = new Road(359.999, 1, 1);
+
+        assertEquals(359.999, road.getAngle());
+    }
+
+    @Test
+    void constructor_rejectsNegativeAngle() {
+        assertThrows(IllegalArgumentException.class, () -> new Road(-0.1, 1, 1));
+    }
+
+    @Test
+    void constructor_rejectsFullCircleAngle() {
+        assertThrows(IllegalArgumentException.class, () -> new Road(360.0, 1, 1));
+    }
+
+    @Test
+    void setAngle_acceptsValidUpdatedAngle() {
+        Road road = new Road(90.0, 1, 1);
+
+        road.setAngle(180.0);
+
+        assertEquals(180.0, road.getAngle());
+    }
+
+    @Test
+    void setAngle_rejectsOutOfRangeAngleAndKeepsExistingValue() {
+        Road road = new Road(90.0, 1, 1);
+
+        assertThrows(IllegalArgumentException.class, () -> road.setAngle(360.0));
+
+        assertEquals(90.0, road.getAngle());
+    }
+
+    @Test
+    void setAngle_acceptsRepresentativeCardinalAngles() {
+        Road road = new Road(0.0, 1, 1);
+
+        assertDoesNotThrow(() -> {
+            road.setAngle(90.0);
+            road.setAngle(180.0);
+            road.setAngle(270.0);
+        });
+
+        assertEquals(270.0, road.getAngle());
+    }
+}


### PR DESCRIPTION
### Motivation

- Add an automated test framework and coverage reporting so CI and SonarCloud can consume unit-test coverage. 
- Ensure JUnit 5 tests run in the Maven lifecycle and produce JaCoCo XML for Sonar Cloud analysis. 
- Add targeted unit tests to improve confidence in `Intersection` and `Road` validation logic. 
- Increment the pre-MVP development version to reflect the new test/coverage work using SemVer (`0.3.0-SNAPSHOT` → `0.4.0-SNAPSHOT`).

### Description

- Updated `pom.xml` to centralize versions and wire JUnit (`junit-jupiter`), Maven Surefire (`maven-surefire-plugin`), and JaCoCo (`jacoco-maven-plugin`) with `prepare-agent` and `report` executions so `mvn verify` generates `target/site/jacoco/jacoco.xml`. 
- Added `sonar.coverage.jacoco.xmlReportPaths` property and updated CI workflow (`.github/workflows/build.yml`) to run Maven with the `sonarcloud` profile so the Sonar scanner imports the JaCoCo XML report. 
- Added tests: expanded `IntersectionTest` with road-count and add-road validation tests and added new `RoadTest` covering angle bounds and update behavior. 
- Updated `README.md` and `CHANGELOG.md` to document the automated test/coverage workflow, the JaCoCo report location, CI changes, and bumped development version to `0.4.0-SNAPSHOT`.

### Testing

- Ran `mvn -B verify` to exercise the new lifecycle and coverage generation but the build failed while resolving `org.jacoco:jacoco-maven-plugin:0.8.12` due to a Maven Central HTTP 403 (environment/network blocking), so tests/JaCoCo report generation could not complete. 
- Verified `pom.xml` is well-formed by parsing it with Python (`xml.etree.ElementTree.parse('pom.xml')`) which succeeded. 
- Ran repository verification steps including `git diff --check` and created a commit with commitizen-style message `test: add jacoco coverage reporting`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21766b38f48325a2cee433689c5258)