### PR TITLE
test: expand model unit coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ the current `0.x` baseline.
 
 ### Added
 
+- Added comprehensive model unit tests for traffic-light validation, group
+  add/remove and bulk-update behavior, lane routing constraints, pedestrian
+  crossing requests, and pedestrian button press/reset lifecycles.
 - Added JaCoCo coverage instrumentation and XML report generation during
   `mvn verify`, plus SonarQube Cloud coverage report path wiring for CI
   analysis.
@@ -45,6 +48,10 @@ the current `0.x` baseline.
 
 ### Changed
 
+- Incremented the pre-MVP development version from `0.4.0-SNAPSHOT` to
+  `0.5.0-SNAPSHOT` for the expanded model test coverage baseline.
+- Hardened `TrafficLight` and `Lane` input validation so null constructor and
+  mutator arguments fail with clear `IllegalArgumentException` messages.
 - Incremented the pre-MVP development version from `0.3.0-SNAPSHOT` to
   `0.4.0-SNAPSHOT` for the automated testing and coverage framework.
 - Updated CI to run SonarQube Cloud analysis with the `sonarcloud` profile so

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simulation domain objects.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.4.0-SNAPSHOT`
+- **Current development version:** `0.5.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -46,7 +46,10 @@ mvn -B verify
 ```
 
 The JaCoCo XML report is generated at
-`target/site/jacoco/jacoco.xml`.
+`target/site/jacoco/jacoco.xml`. The model package unit-test suite covers
+traffic-light validation and group safety rules, lane routing constraints, and
+pedestrian button/crossing request lifecycles so coverage gates exercise the
+core domain behavior.
 
 ## Running the application
 
@@ -60,7 +63,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.4.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.5.0-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/model/Lane.java
+++ b/src/main/java/com/trafficlightsimulator/model/Lane.java
@@ -17,12 +17,18 @@ public class Lane {
 
     // Constructor
     public Lane(Direction direction) {
+        if (direction == null) {
+            throw new IllegalArgumentException("Lane direction must not be null.");
+        }
         this.direction = direction;
         this.allowedOutgoingLanes = new ArrayList<>();
     }
 
     // Method to add an allowed outgoing lane (only applicable for incoming lanes)
     public void addAllowedOutgoingLane(Lane lane) {
+        if (lane == null) {
+            throw new IllegalArgumentException("Allowed outgoing lane must not be null.");
+        }
         if (this.direction == Direction.INCOMING && lane.direction == Direction.OUTGOING) {
             allowedOutgoingLanes.add(lane);
             logger.log(Level.INFO, "Added allowed outgoing lane: {0}", lane);

--- a/src/main/java/com/trafficlightsimulator/model/TrafficLight.java
+++ b/src/main/java/com/trafficlightsimulator/model/TrafficLight.java
@@ -19,11 +19,17 @@ public class TrafficLight {
 
     // Constructor
     public TrafficLight(Color color, State state, Type type, Direction direction, boolean isMultiColor) {
-        this.color = color;
-        this.state = state;
+        if (type == null) {
+            throw new IllegalArgumentException("Traffic light type must not be null.");
+        }
+        if (direction == null) {
+            throw new IllegalArgumentException("Direction must not be null.");
+        }
         this.type = type;
         this.direction = direction;
         this.isMultiColor = isMultiColor;
+        setColor(color);
+        setState(state);
     }
 
     // Getters and Setters
@@ -46,6 +52,9 @@ public class TrafficLight {
     }
 
     public void setState(State state) {
+        if (state == null) {
+            throw new IllegalArgumentException("State must not be null.");
+        }
         this.state = state;
     }
 
@@ -58,6 +67,9 @@ public class TrafficLight {
     }
 
     public void setDirection(Direction direction) {
+        if (direction == null) {
+            throw new IllegalArgumentException("Direction must not be null.");
+        }
         this.direction = direction;
     }
 

--- a/src/test/java/com/trafficlightsimulator/model/LaneTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/LaneTest.java
@@ -1,0 +1,71 @@
+package com.trafficlightsimulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LaneTest {
+
+    @Test
+    void constructor_initializesDirectionAndEmptyAllowedOutgoingLanes() {
+        Lane lane = new Lane(Lane.Direction.INCOMING);
+
+        assertEquals(Lane.Direction.INCOMING, lane.getDirection());
+        assertTrue(lane.getAllowedOutgoingLanes().isEmpty());
+    }
+
+    @Test
+    void constructor_rejectsNullDirection() {
+        assertThrows(IllegalArgumentException.class, () -> new Lane(null));
+    }
+
+    @Test
+    void addAllowedOutgoingLane_allowsIncomingToOutgoingLane() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane outgoing = new Lane(Lane.Direction.OUTGOING);
+
+        incoming.addAllowedOutgoingLane(outgoing);
+
+        assertEquals(1, incoming.getAllowedOutgoingLanes().size());
+        assertSame(outgoing, incoming.getAllowedOutgoingLanes().get(0));
+        assertTrue(incoming.isAllowedOutgoingLane(outgoing));
+    }
+
+    @Test
+    void addAllowedOutgoingLane_rejectsIncomingToIncomingLane() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane otherIncoming = new Lane(Lane.Direction.INCOMING);
+
+        assertThrows(IllegalArgumentException.class, () -> incoming.addAllowedOutgoingLane(otherIncoming));
+
+        assertFalse(incoming.isAllowedOutgoingLane(otherIncoming));
+    }
+
+    @Test
+    void addAllowedOutgoingLane_rejectsOutgoingLaneAsSource() {
+        Lane outgoingSource = new Lane(Lane.Direction.OUTGOING);
+        Lane outgoingTarget = new Lane(Lane.Direction.OUTGOING);
+
+        assertThrows(IllegalArgumentException.class, () -> outgoingSource.addAllowedOutgoingLane(outgoingTarget));
+
+        assertFalse(outgoingSource.isAllowedOutgoingLane(outgoingTarget));
+    }
+
+    @Test
+    void addAllowedOutgoingLane_rejectsNullLane() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+
+        assertThrows(IllegalArgumentException.class, () -> incoming.addAllowedOutgoingLane(null));
+
+        assertTrue(incoming.getAllowedOutgoingLanes().isEmpty());
+    }
+
+    @Test
+    void isAllowedOutgoingLane_returnsFalseForUnregisteredAndNullLanes() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane outgoing = new Lane(Lane.Direction.OUTGOING);
+
+        assertFalse(incoming.isAllowedOutgoingLane(outgoing));
+        assertFalse(incoming.isAllowedOutgoingLane(null));
+    }
+}

--- a/src/test/java/com/trafficlightsimulator/model/PedestrianButtonTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/PedestrianButtonTest.java
@@ -1,0 +1,38 @@
+package com.trafficlightsimulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PedestrianButtonTest {
+
+    @Test
+    void constructor_startsUnpressedAndRetainsLightGroupReference() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        PedestrianButton button = new PedestrianButton(group);
+
+        assertFalse(button.isPressed());
+        assertSame(group, button.getPedestrianLightGroup());
+    }
+
+    @Test
+    void press_setsPressedStateAndIsIdempotent() {
+        PedestrianButton button = new PedestrianButton(new TrafficLightGroup());
+
+        button.press();
+        button.press();
+
+        assertTrue(button.isPressed());
+    }
+
+    @Test
+    void reset_clearsPressedStateAndIsIdempotent() {
+        PedestrianButton button = new PedestrianButton(new TrafficLightGroup());
+        button.press();
+
+        button.reset();
+        button.reset();
+
+        assertFalse(button.isPressed());
+    }
+}

--- a/src/test/java/com/trafficlightsimulator/model/PedestrianCrossingTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/PedestrianCrossingTest.java
@@ -1,0 +1,84 @@
+package com.trafficlightsimulator.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PedestrianCrossingTest {
+
+    @Test
+    void noButtonConstructor_initializesPedestrianLightGroupAndNoRequest() {
+        PedestrianCrossing crossing = new PedestrianCrossing();
+
+        assertNotNull(crossing.getPedestrianLightGroup());
+        assertTrue(crossing.getButtonAtStart().isEmpty());
+        assertTrue(crossing.getButtonAtEnd().isEmpty());
+        assertFalse(crossing.isCrossingRequested());
+    }
+
+    @Test
+    void buttonConstructor_wrapsNullableButtons() {
+        PedestrianButton startButton = new PedestrianButton(new TrafficLightGroup());
+
+        PedestrianCrossing crossing = new PedestrianCrossing(startButton, null);
+
+        assertTrue(crossing.getButtonAtStart().isPresent());
+        assertSame(startButton, crossing.getButtonAtStart().orElseThrow());
+        assertTrue(crossing.getButtonAtEnd().isEmpty());
+    }
+
+    @Test
+    void isCrossingRequested_reflectsStartOrEndButtonPress() {
+        PedestrianButton startButton = new PedestrianButton(new TrafficLightGroup());
+        PedestrianButton endButton = new PedestrianButton(new TrafficLightGroup());
+        PedestrianCrossing crossing = new PedestrianCrossing(startButton, endButton);
+
+        assertFalse(crossing.isCrossingRequested());
+
+        startButton.press();
+        assertTrue(crossing.isCrossingRequested());
+
+        startButton.reset();
+        endButton.press();
+        assertTrue(crossing.isCrossingRequested());
+    }
+
+    @Test
+    void resetButtons_resetsBothButtons() {
+        PedestrianButton startButton = new PedestrianButton(new TrafficLightGroup());
+        PedestrianButton endButton = new PedestrianButton(new TrafficLightGroup());
+        PedestrianCrossing crossing = new PedestrianCrossing(startButton, endButton);
+        startButton.press();
+        endButton.press();
+
+        crossing.resetButtons();
+
+        assertFalse(startButton.isPressed());
+        assertFalse(endButton.isPressed());
+        assertFalse(crossing.isCrossingRequested());
+    }
+
+    @Test
+    void resetButtons_isSafeWhenButtonsAreAbsent() {
+        PedestrianCrossing crossing = new PedestrianCrossing();
+
+        assertDoesNotThrow(crossing::resetButtons);
+        assertFalse(crossing.isCrossingRequested());
+    }
+
+    @Test
+    void addPedestrianLight_addsOnlyPedestrianLightsAndIgnoresNulls() {
+        PedestrianCrossing crossing = new PedestrianCrossing();
+        TrafficLight pedestrianLight = new TrafficLight(Color.RED, State.ON,
+                TrafficLight.Type.PEDESTRIAN, Direction.NONE, false);
+        TrafficLight trafficLight = new TrafficLight(Color.RED, State.ON,
+                TrafficLight.Type.TRAFFIC, Direction.STRAIGHT, true);
+
+        crossing.addPedestrianLight(pedestrianLight);
+        crossing.addPedestrianLight(trafficLight);
+        crossing.addPedestrianLight(null);
+
+        assertEquals(1, crossing.getPedestrianLightGroup().getLights().size());
+        assertSame(pedestrianLight, crossing.getPedestrianLightGroup().getLights().get(0));
+    }
+}

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
@@ -9,6 +9,35 @@ import static org.junit.jupiter.api.Assertions.*;
 class TrafficLightGroupTest {
 
     @Test
+    void addTrafficLight_tracksNonNullLightsAndIgnoresNulls() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight light = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+
+        group.addTrafficLight(light);
+        group.addTrafficLight(null);
+
+        assertEquals(1, group.getLights().size());
+        assertSame(light, group.getLights().get(0));
+        assertTrue(group.getIncompatibleLights(light).isEmpty());
+    }
+
+    @Test
+    void removeTrafficLight_removesMembershipAndConfiguredIncompatibilities() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight northbound = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+        TrafficLight eastbound = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        group.addTrafficLight(northbound);
+        group.addTrafficLight(eastbound);
+        group.addIncompatibleLights(northbound, eastbound);
+
+        group.removeTrafficLight(eastbound);
+
+        assertFalse(group.getLights().contains(eastbound));
+        assertFalse(group.areIncompatible(northbound, eastbound));
+        assertTrue(group.getIncompatibleLights(northbound).isEmpty());
+    }
+
+    @Test
     void addIncompatibleLights_configuresSymmetricIdentityRelationship() {
         TrafficLightGroup group = new TrafficLightGroup();
         TrafficLight northbound = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
@@ -21,6 +50,48 @@ class TrafficLightGroupTest {
         assertTrue(group.areIncompatible(northbound, eastbound));
         assertTrue(group.areIncompatible(eastbound, northbound));
         assertEquals(Set.of(eastbound), group.getIncompatibleLights(northbound));
+    }
+
+    @Test
+    void addIncompatibleLights_rejectsNullsAndSelfRelationship() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight light = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () -> group.addIncompatibleLights(null, light)),
+                () -> assertThrows(IllegalArgumentException.class, () -> group.addIncompatibleLights(light, null)),
+                () -> assertThrows(IllegalArgumentException.class, () -> group.addIncompatibleLights(light, light))
+        );
+    }
+
+    @Test
+    void removeIncompatibleLights_removesSymmetricRelationshipAndRejectsNulls() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight northbound = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+        TrafficLight eastbound = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        group.addIncompatibleLights(northbound, eastbound);
+
+        group.removeIncompatibleLights(northbound, eastbound);
+
+        assertFalse(group.areIncompatible(northbound, eastbound));
+        assertFalse(group.areIncompatible(eastbound, northbound));
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () -> group.removeIncompatibleLights(null, eastbound)),
+                () -> assertThrows(IllegalArgumentException.class, () -> group.removeIncompatibleLights(northbound, null))
+        );
+    }
+
+    @Test
+    void getIncompatibleLights_rejectsNullAndExposesReadOnlyView() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight northbound = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+        TrafficLight eastbound = trafficLight(Direction.LEFT, Color.RED, State.ON);
+        group.addIncompatibleLights(northbound, eastbound);
+
+        Set<TrafficLight> incompatibleLights = group.getIncompatibleLights(northbound);
+
+        assertThrows(UnsupportedOperationException.class, () -> incompatibleLights.add(trafficLight(Direction.RIGHT, Color.RED, State.ON)));
+        assertThrows(IllegalArgumentException.class, () -> group.getIncompatibleLights(null));
     }
 
     @Test
@@ -76,7 +147,65 @@ class TrafficLightGroupTest {
         assertThrows(IllegalArgumentException.class, () -> group.setLightColor(ungrouped, Color.GREEN));
     }
 
+    @Test
+    void setLightState_requiresLightToBelongToGroup() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight ungrouped = trafficLight(Direction.NONE, Color.RED, State.ON);
+
+        assertThrows(IllegalArgumentException.class, () -> group.setLightState(ungrouped, State.OFF));
+    }
+
+    @Test
+    void setAllLightsState_updatesEveryCompatibleLight() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight straight = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+        TrafficLight left = trafficLight(Direction.LEFT, Color.GREEN, State.ON);
+        group.addTrafficLight(straight);
+        group.addTrafficLight(left);
+
+        group.setAllLightsState(State.OFF);
+
+        assertEquals(State.OFF, straight.getState());
+        assertEquals(State.OFF, left.getState());
+    }
+
+    @Test
+    void setAllLightsState_continuesAfterConflictWarningPath() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight active = trafficLight(Direction.STRAIGHT, Color.GREEN, State.ON);
+        TrafficLight conflicting = trafficLight(Direction.LEFT, Color.GREEN, State.OFF);
+        TrafficLight amber = trafficLight(Direction.RIGHT, Color.AMBER, State.OFF);
+        group.addTrafficLight(active);
+        group.addTrafficLight(conflicting);
+        group.addTrafficLight(amber);
+        group.addIncompatibleLights(active, conflicting);
+
+        group.setAllLightsState(State.ON);
+
+        assertEquals(State.ON, active.getState());
+        assertEquals(State.OFF, conflicting.getState());
+        assertEquals(State.ON, amber.getState());
+    }
+
+    @Test
+    void setAllLightsColor_updatesSupportedLightsAndContinuesAfterValidationWarning() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight trafficLight = trafficLight(Direction.STRAIGHT, Color.RED, State.OFF);
+        TrafficLight pedestrianLight = pedestrianLight(Color.RED, State.OFF);
+        group.addTrafficLight(trafficLight);
+        group.addTrafficLight(pedestrianLight);
+
+        group.setAllLightsColor(Color.AMBER);
+
+        assertEquals(Color.AMBER, trafficLight.getColor());
+        assertEquals(Color.RED, pedestrianLight.getColor());
+    }
+
     private TrafficLight trafficLight(Direction direction, Color color, State state) {
         return new TrafficLight(color, state, TrafficLight.Type.TRAFFIC, direction, true);
+    }
+
+    private TrafficLight pedestrianLight(Color color, State state) {
+        return new TrafficLight(color, state, TrafficLight.Type.PEDESTRIAN, Direction.NONE, false);
     }
 }

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
@@ -89,8 +89,9 @@ class TrafficLightGroupTest {
         group.addIncompatibleLights(northbound, eastbound);
 
         Set<TrafficLight> incompatibleLights = group.getIncompatibleLights(northbound);
+        TrafficLight additionalLight = trafficLight(Direction.RIGHT, Color.RED, State.ON);
 
-        assertThrows(UnsupportedOperationException.class, () -> incompatibleLights.add(trafficLight(Direction.RIGHT, Color.RED, State.ON)));
+        assertThrows(UnsupportedOperationException.class, () -> incompatibleLights.add(additionalLight));
         assertThrows(IllegalArgumentException.class, () -> group.getIncompatibleLights(null));
     }
 

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightTest.java
@@ -1,105 +1,143 @@
 package com.trafficlightsimulator.model;
 
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class TrafficLightTest {
 
+    @Test
+    void constructor_initializesAllProperties() {
+        TrafficLight light = new TrafficLight(Color.GREEN, State.OFF,
+                TrafficLight.Type.TRAFFIC, Direction.LEFT, true);
+
+        assertAll(
+                () -> assertEquals(Color.GREEN, light.getColor()),
+                () -> assertEquals(State.OFF, light.getState()),
+                () -> assertEquals(TrafficLight.Type.TRAFFIC, light.getType()),
+                () -> assertEquals(Direction.LEFT, light.getDirection()),
+                () -> assertTrue(light.isMultiColor())
+        );
+    }
+
+    @Test
+    void constructor_rejectsNullColor() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrafficLight(null, State.ON, TrafficLight.Type.TRAFFIC, Direction.NONE, true));
+    }
+
+    @Test
+    void constructor_rejectsNullState() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrafficLight(Color.RED, null, TrafficLight.Type.TRAFFIC, Direction.NONE, true));
+    }
+
+    @Test
+    void constructor_rejectsNullType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrafficLight(Color.RED, State.ON, null, Direction.NONE, true));
+    }
+
+    @Test
+    void constructor_rejectsNullDirection() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrafficLight(Color.RED, State.ON, TrafficLight.Type.TRAFFIC, null, true));
+    }
+
+    @Test
+    void constructor_rejectsAmberPedestrianLight() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrafficLight(Color.AMBER, State.ON, TrafficLight.Type.PEDESTRIAN, Direction.NONE, true));
+    }
+
+    @Test
+    void trafficMultiColor_acceptsAllSignalColors() {
+        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
+
+        light.setColor(Color.RED);
+        assertEquals(Color.RED, light.getColor());
+
+        light.setColor(Color.AMBER);
+        assertEquals(Color.AMBER, light.getColor());
+
+        light.setColor(Color.GREEN);
+        assertEquals(Color.GREEN, light.getColor());
+    }
+
+    @Test
+    void trafficSingleColor_acceptsAllSignalColors() {
+        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, false);
+
+        light.setColor(Color.RED);
+        assertEquals(Color.RED, light.getColor());
+
+        light.setColor(Color.AMBER);
+        assertEquals(Color.AMBER, light.getColor());
+
+        light.setColor(Color.GREEN);
+        assertEquals(Color.GREEN, light.getColor());
+    }
+
+    @Test
+    void pedestrianMultiColor_acceptsRedAndGreenButRejectsAmber() {
+        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, true);
+
+        light.setColor(Color.RED);
+        assertEquals(Color.RED, light.getColor());
+
+        light.setColor(Color.GREEN);
+        assertEquals(Color.GREEN, light.getColor());
+
+        assertThrows(IllegalArgumentException.class, () -> light.setColor(Color.AMBER));
+        assertEquals(Color.GREEN, light.getColor());
+    }
+
+    @Test
+    void pedestrianSingleColor_acceptsRedAndGreenButRejectsAmber() {
+        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, false);
+
+        light.setColor(Color.RED);
+        assertEquals(Color.RED, light.getColor());
+
+        light.setColor(Color.GREEN);
+        assertEquals(Color.GREEN, light.getColor());
+
+        assertThrows(IllegalArgumentException.class, () -> light.setColor(Color.AMBER));
+        assertEquals(Color.GREEN, light.getColor());
+    }
+
+    @Test
+    void setColor_rejectsNullAndKeepsExistingColor() {
+        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
+
+        assertThrows(IllegalArgumentException.class, () -> light.setColor(null));
+
+        assertEquals(Color.RED, light.getColor());
+    }
+
+    @Test
+    void setState_updatesStateAndRejectsNull() {
+        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
+
+        light.setState(State.OFF);
+        assertEquals(State.OFF, light.getState());
+
+        assertThrows(IllegalArgumentException.class, () -> light.setState(null));
+        assertEquals(State.OFF, light.getState());
+    }
+
+    @Test
+    void setDirection_updatesDirectionAndRejectsNull() {
+        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
+
+        light.setDirection(Direction.RIGHT);
+        assertEquals(Direction.RIGHT, light.getDirection());
+
+        assertThrows(IllegalArgumentException.class, () -> light.setDirection(null));
+        assertEquals(Direction.RIGHT, light.getDirection());
+    }
+
     private TrafficLight trafficLight(TrafficLight.Type type, boolean multiColor) {
         return new TrafficLight(Color.RED, State.ON, type, Direction.NONE, multiColor);
-    }
-
-    // --- TRAFFIC type ---
-
-    @Test
-    void trafficMultiColor_acceptsRed() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
-        light.setColor(Color.RED);
-        assertEquals(Color.RED, light.getColor());
-    }
-
-    @Test
-    void trafficMultiColor_acceptsAmber() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
-        light.setColor(Color.AMBER);
-        assertEquals(Color.AMBER, light.getColor());
-    }
-
-    @Test
-    void trafficMultiColor_acceptsGreen() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
-        light.setColor(Color.GREEN);
-        assertEquals(Color.GREEN, light.getColor());
-    }
-
-    @Test
-    void trafficSingleColor_acceptsRed() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, false);
-        light.setColor(Color.RED);
-        assertEquals(Color.RED, light.getColor());
-    }
-
-    @Test
-    void trafficSingleColor_acceptsAmber() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, false);
-        light.setColor(Color.AMBER);
-        assertEquals(Color.AMBER, light.getColor());
-    }
-
-    @Test
-    void trafficSingleColor_acceptsGreen() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, false);
-        light.setColor(Color.GREEN);
-        assertEquals(Color.GREEN, light.getColor());
-    }
-
-    // --- PEDESTRIAN type ---
-
-    @Test
-    void pedestrianMultiColor_acceptsRed() {
-        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, true);
-        light.setColor(Color.RED);
-        assertEquals(Color.RED, light.getColor());
-    }
-
-    @Test
-    void pedestrianMultiColor_acceptsGreen() {
-        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, true);
-        light.setColor(Color.GREEN);
-        assertEquals(Color.GREEN, light.getColor());
-    }
-
-    @Test
-    void pedestrianMultiColor_rejectsAmber() {
-        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, true);
-        assertThrows(IllegalArgumentException.class, () -> light.setColor(Color.AMBER));
-    }
-
-    @Test
-    void pedestrianSingleColor_acceptsRed() {
-        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, false);
-        light.setColor(Color.RED);
-        assertEquals(Color.RED, light.getColor());
-    }
-
-    @Test
-    void pedestrianSingleColor_acceptsGreen() {
-        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, false);
-        light.setColor(Color.GREEN);
-        assertEquals(Color.GREEN, light.getColor());
-    }
-
-    @Test
-    void pedestrianSingleColor_rejectsAmber() {
-        TrafficLight light = trafficLight(TrafficLight.Type.PEDESTRIAN, false);
-        assertThrows(IllegalArgumentException.class, () -> light.setColor(Color.AMBER));
-    }
-
-    // --- Null guard ---
-
-    @Test
-    void setColor_rejectsNull() {
-        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
-        assertThrows(IllegalArgumentException.class, () -> light.setColor(null));
     }
 }


### PR DESCRIPTION
### Motivation

- Improve unit-test coverage across the model package so core domain behavior is validated and regressions are detected early.
- Exercise and harden input validation for model classes to make error cases fail fast with clear diagnostics.
- Establish a test baseline and update project metadata/docs to reflect expanded model coverage for CI and releases.

### Description

- Added comprehensive JUnit tests for `TrafficLight`, `TrafficLightGroup`, `Lane`, `PedestrianButton`, and `PedestrianCrossing` covering constructors, validation, mutation behavior, incompatibility rules, and bulk-update paths.
- Hardened `TrafficLight` to validate `type`, `direction`, `state`, and `color` (null checks and AMBER rejection for pedestrian lights) and updated `setState`/`setDirection` to throw `IllegalArgumentException` on `null` inputs.
- Hardened `Lane` constructor and `addAllowedOutgoingLane` to reject `null` arguments and enforce incoming->outgoing lane rules with clear `IllegalArgumentException` messages.
- Updated `TrafficLightGroup` tests to cover add/remove, symmetric incompatible relationships, `getIncompatibleLights` read-only view, `setLightColor`/`setLightState` safety checks, and bulk update warning/continue behavior; added tests for group membership guards.
- Bumped development version in `pom.xml` to `0.5.0-SNAPSHOT` and updated `README.md` and `CHANGELOG.md` to document the new tests and the stronger validation rules.

### Testing

- Attempted to run Maven tests with `mvn -B test` and full verification with `mvn -B verify`, but both runs were blocked by a network/environment issue where Maven Central returned `403 Forbidden` while resolving the JaCoCo plugin (`org.jacoco:jacoco-maven-plugin:0.8.12`).
- Executed a local compilation and test harness (lightweight JUnit-compatible stubs + reflection runner) to compile and run the model test suite: `javac` + custom `runner.TestRunner` — 56 tests passed, 0 failures.
- Performed `git diff --check` to ensure no whitespace/format issues were introduced and updated `README.md`/`CHANGELOG.md` as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2182f98be883259ac01913efad15a1)