### PR TITLE
Harden Road/Intersection validation and fix non-destructive lane resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ the current `0.x` baseline.
 
 ### Added
 
+- Added tests for `Road` lane-count validation (zero and negative counts rejected) and
+  non-destructive lane resize (growth preserves existing lane objects; shrink removes
+  only tail lanes) for both incoming and outgoing lanes.
+- Added tests for `Intersection.setNumberOfRoads` guarding against shrinking the
+  capacity below the number of roads already added, including the equal-to-count
+  boundary case.
+
+### Fixed
+
+- `Road.setNumIncomingLanes` and `Road.setNumOutgoingLanes` previously cleared and
+  rebuilt the entire lane list on every call, silently discarding configured turn
+  restrictions and traffic-light assignments. The resize is now incremental: lanes are
+  appended when growing and only tail lanes are removed when shrinking, preserving all
+  existing lane configuration.
+- `Road.setNumIncomingLanes` and `Road.setNumOutgoingLanes` previously accepted zero
+  and negative counts, storing the invalid value while producing no lanes. Both setters
+  now reject any count below 1 with `IllegalArgumentException`.
+- `Intersection.setNumberOfRoads` could previously be called with a value lower than
+  the number of roads already added, making `isIntersectionSetupComplete()` permanently
+  false with no path to recovery. The setter now rejects any value below `roads.size()`
+  with `IllegalArgumentException`.
+
+### Changed
+
+- Incremented the pre-MVP development version from `0.5.0-SNAPSHOT` to
+  `0.6.0-SNAPSHOT` for the hardened Road/Intersection validation and non-destructive
+  lane resize.
+
+### Added
+
 - Added comprehensive model unit tests for traffic-light validation, group
   add/remove and bulk-update behavior, lane routing constraints, pedestrian
   crossing requests, and pedestrian button press/reset lifecycles.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -24,6 +24,10 @@ public class Intersection {
         if (numberOfRoads < MIN_ROADS || numberOfRoads > MAX_ROADS) {
             throw new IllegalArgumentException("Number of roads must be between " + MIN_ROADS + " and " + MAX_ROADS);
         }
+        if (roads != null && numberOfRoads < roads.size()) {
+            throw new IllegalArgumentException(
+                    "Number of roads cannot be less than the number of roads already added: " + roads.size());
+        }
         this.numberOfRoads = numberOfRoads;
         logger.log(Level.INFO, "Number of roads set to: {0}", numberOfRoads);
     }

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -43,11 +43,18 @@ public class Road {
 
     // Setter for number of incoming lanes
     public void setNumIncomingLanes(int numIncomingLanes) {
-        this.numIncomingLanes = numIncomingLanes;
-        this.incomingLanes.clear();
-        for (int i = 0; i < numIncomingLanes; i++) {
-            this.incomingLanes.add(new Lane(Lane.Direction.INCOMING));
+        if (numIncomingLanes < 1) {
+            throw new IllegalArgumentException("Number of incoming lanes must be at least 1.");
         }
+        int current = this.incomingLanes.size();
+        if (numIncomingLanes > current) {
+            for (int i = current; i < numIncomingLanes; i++) {
+                this.incomingLanes.add(new Lane(Lane.Direction.INCOMING));
+            }
+        } else if (numIncomingLanes < current) {
+            this.incomingLanes.subList(numIncomingLanes, current).clear();
+        }
+        this.numIncomingLanes = numIncomingLanes;
         logger.log(Level.INFO, "Number of incoming lanes set to: {0}", numIncomingLanes);
     }
 
@@ -58,11 +65,18 @@ public class Road {
 
     // Setter for number of outgoing lanes
     public void setNumOutgoingLanes(int numOutgoingLanes) {
-        this.numOutgoingLanes = numOutgoingLanes;
-        this.outgoingLanes.clear();
-        for (int i = 0; i < numOutgoingLanes; i++) {
-            this.outgoingLanes.add(new Lane(Lane.Direction.OUTGOING));
+        if (numOutgoingLanes < 1) {
+            throw new IllegalArgumentException("Number of outgoing lanes must be at least 1.");
         }
+        int current = this.outgoingLanes.size();
+        if (numOutgoingLanes > current) {
+            for (int i = current; i < numOutgoingLanes; i++) {
+                this.outgoingLanes.add(new Lane(Lane.Direction.OUTGOING));
+            }
+        } else if (numOutgoingLanes < current) {
+            this.outgoingLanes.subList(numOutgoingLanes, current).clear();
+        }
+        this.numOutgoingLanes = numOutgoingLanes;
         logger.log(Level.INFO, "Number of outgoing lanes set to: {0}", numOutgoingLanes);
     }
 

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -52,6 +52,29 @@ class IntersectionTest {
     }
 
     @Test
+    void setNumberOfRoads_rejectsValueBelowCurrentRoadCount() {
+        Intersection intersection = new Intersection(4);
+        intersection.addRoad(new Road(0.0, 1, 1));
+        intersection.addRoad(new Road(90.0, 1, 1));
+        intersection.addRoad(new Road(180.0, 1, 1));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> intersection.setNumberOfRoads(2));
+
+        assertTrue(exception.getMessage().contains("already added"));
+    }
+
+    @Test
+    void setNumberOfRoads_acceptsValueEqualToCurrentRoadCount() {
+        Intersection intersection = new Intersection(4);
+        intersection.addRoad(new Road(0.0, 1, 1));
+        intersection.addRoad(new Road(90.0, 1, 1));
+        intersection.addRoad(new Road(180.0, 1, 1));
+
+        assertDoesNotThrow(() -> intersection.setNumberOfRoads(3));
+    }
+
+    @Test
     void configureIncompatibleTrafficLights_enforcesConflictsAcrossRoadGroups() {
         Intersection intersection = new Intersection(2);
         Road northRoad = new Road(0.0, 1, 1);

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RoadTest {
@@ -61,5 +62,73 @@ class RoadTest {
         });
 
         assertEquals(270.0, road.getAngle());
+    }
+
+    @Test
+    void constructor_rejectsZeroIncomingLaneCount() {
+        assertThrows(IllegalArgumentException.class, () -> new Road(0.0, 0, 1));
+    }
+
+    @Test
+    void constructor_rejectsNegativeIncomingLaneCount() {
+        assertThrows(IllegalArgumentException.class, () -> new Road(0.0, -1, 1));
+    }
+
+    @Test
+    void constructor_rejectsZeroOutgoingLaneCount() {
+        assertThrows(IllegalArgumentException.class, () -> new Road(0.0, 1, 0));
+    }
+
+    @Test
+    void constructor_rejectsNegativeOutgoingLaneCount() {
+        assertThrows(IllegalArgumentException.class, () -> new Road(0.0, 1, -1));
+    }
+
+    @Test
+    void setNumIncomingLanes_growthPreservesExistingLaneObjects() {
+        Road road = new Road(0.0, 2, 1);
+        Lane originalFirst = road.getIncomingLanes().get(0);
+        Lane originalSecond = road.getIncomingLanes().get(1);
+
+        road.setNumIncomingLanes(4);
+
+        assertSame(originalFirst, road.getIncomingLanes().get(0));
+        assertSame(originalSecond, road.getIncomingLanes().get(1));
+        assertEquals(4, road.getIncomingLanes().size());
+    }
+
+    @Test
+    void setNumIncomingLanes_shrinkRemovesFromTailAndPreservesHead() {
+        Road road = new Road(0.0, 3, 1);
+        Lane originalFirst = road.getIncomingLanes().get(0);
+
+        road.setNumIncomingLanes(1);
+
+        assertEquals(1, road.getIncomingLanes().size());
+        assertSame(originalFirst, road.getIncomingLanes().get(0));
+    }
+
+    @Test
+    void setNumOutgoingLanes_growthPreservesExistingLaneObjects() {
+        Road road = new Road(0.0, 1, 2);
+        Lane originalFirst = road.getOutgoingLanes().get(0);
+        Lane originalSecond = road.getOutgoingLanes().get(1);
+
+        road.setNumOutgoingLanes(4);
+
+        assertSame(originalFirst, road.getOutgoingLanes().get(0));
+        assertSame(originalSecond, road.getOutgoingLanes().get(1));
+        assertEquals(4, road.getOutgoingLanes().size());
+    }
+
+    @Test
+    void setNumOutgoingLanes_shrinkRemovesFromTailAndPreservesHead() {
+        Road road = new Road(0.0, 1, 3);
+        Lane originalFirst = road.getOutgoingLanes().get(0);
+
+        road.setNumOutgoingLanes(1);
+
+        assertEquals(1, road.getOutgoingLanes().size());
+        assertSame(originalFirst, road.getOutgoingLanes().get(0));
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in lane resizing and adds validation to prevent invalid state in Road and Intersection classes. Lane count changes are now incremental (preserving existing lane configuration) rather than destructive, and both Road and Intersection now properly validate input to prevent silent failures.

## Key Changes

**Road Lane Resizing (Non-Destructive)**
- `setNumIncomingLanes()` and `setNumOutgoingLanes()` now use incremental resize instead of clearing and rebuilding
- When growing: new lanes are appended to the existing list
- When shrinking: only tail lanes are removed, preserving head lanes and all their configuration
- This prevents loss of turn restrictions and traffic-light assignments during resize operations

**Input Validation**
- `Road.setNumIncomingLanes()` and `Road.setNumOutgoingLanes()` now reject counts below 1 with `IllegalArgumentException`
- `Intersection.setNumberOfRoads()` now rejects values below the current number of roads already added, preventing unrecoverable invalid state
- Added boundary case handling: `setNumberOfRoads()` accepts values equal to current road count

**Test Coverage**
- Added 4 tests for Road constructor validation (zero and negative lane counts)
- Added 4 tests for non-destructive lane resize behavior (growth preserves objects, shrink removes only tail)
- Added 2 tests for Intersection capacity validation (rejects below current count, accepts equal count)

## Implementation Details
- Lane resize uses `subList().clear()` for efficient tail removal without creating new list objects
- Validation occurs before state changes to maintain atomicity
- All existing lane objects are preserved during growth, maintaining object identity for configured state

https://claude.ai/code/session_01W4QzZdp9uLmvEAPvnxub1y