### PR TITLE
fix(model): return unmodifiable collection views from model getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the current `0.x` baseline.
 
 ### Added
 
+- Added encapsulation regression tests proving model collection getters expose
+  read-only views and external mutation attempts throw `UnsupportedOperationException`.
 - Added pedestrian button/crossing linkage tests showing that buttons attached to a
   crossing reference the crossing-owned pedestrian light group, can request the
   crossing that owns those lights, and cannot be reused by another crossing.
@@ -48,6 +50,10 @@ the current `0.x` baseline.
 
 ### Changed
 
+- Incremented the pre-MVP development version from `0.7.0-SNAPSHOT` to
+  `0.8.0-SNAPSHOT` for the model collection getter encapsulation hardening.
+- Changed model collection getters for intersections, roads, traffic-light groups,
+  and lanes to expose unmodifiable views instead of mutable backing lists.
 - Incremented the pre-MVP development version from `0.6.0-SNAPSHOT` to
   `0.7.0-SNAPSHOT` for the pedestrian crossing/button relationship cleanup.
 - Incremented the pre-MVP development version from `0.5.0-SNAPSHOT` to

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simulation domain objects.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.7.0-SNAPSHOT`
+- **Current development version:** `0.8.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -63,7 +63,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.7.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.8.0-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors
@@ -93,6 +93,15 @@ To resolve it:
    mvn -U -B verify
    ```
 
+
+## Model collection encapsulation
+
+Collection getters on core model objects expose read-only views of their backing
+collections. Callers can inspect roads, lanes, traffic lights, and allowed lane
+routes through getters, but structural changes must go through the model methods
+such as `Intersection.addRoad`, `Road.setNumIncomingLanes`,
+`Road.setNumOutgoingLanes`, `TrafficLightGroup.addTrafficLight`, and
+`Lane.addAllowedOutgoingLane` so validation and safety rules remain enforced.
 
 ## Traffic-light safety rules
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -1,6 +1,7 @@
 package com.trafficlightsimulator.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -11,7 +12,7 @@ public class Intersection {
     private static final int MIN_ROADS = 2; // Minimum roads required for an intersection
     private static final int MAX_ROADS = 8; // Maximum roads that can connect to an intersection
     private int numberOfRoads;
-    private List<Road> roads;
+    private final List<Road> roads;
 
     // Constructor with road count parameter
     public Intersection(int numberOfRoads) {
@@ -46,7 +47,7 @@ public class Intersection {
 
     // Method to retrieve all roads in the intersection
     public List<Road> getRoads() {
-        return roads;
+        return Collections.unmodifiableList(roads);
     }
 
     // Method to retrieve all lanes in the intersection (both incoming and outgoing)

--- a/src/main/java/com/trafficlightsimulator/model/Lane.java
+++ b/src/main/java/com/trafficlightsimulator/model/Lane.java
@@ -1,6 +1,7 @@
 package com.trafficlightsimulator.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -13,7 +14,7 @@ public class Lane {
     }
 
     private final Direction direction;
-    private List<Lane> allowedOutgoingLanes;
+    private final List<Lane> allowedOutgoingLanes;
 
     // Constructor
     public Lane(Direction direction) {
@@ -44,7 +45,7 @@ public class Lane {
 
     // Getter for allowed outgoing lanes
     public List<Lane> getAllowedOutgoingLanes() {
-        return allowedOutgoingLanes;
+        return Collections.unmodifiableList(allowedOutgoingLanes);
     }
 
     // Utility method to check if a lane is an allowed outgoing lane

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -1,6 +1,7 @@
 package com.trafficlightsimulator.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -8,8 +9,8 @@ import java.util.logging.Logger;
 public class Road {
     private static final Logger logger = Logger.getLogger(Road.class.getName());
     
-    private List<Lane> incomingLanes;
-    private List<Lane> outgoingLanes;
+    private final List<Lane> incomingLanes;
+    private final List<Lane> outgoingLanes;
     private PedestrianCrossing pedestrianCrossing;
     private TrafficLightGroup incomingLanesTrafficLightGroup;
     private double angle;  // Attribute for road angle
@@ -105,12 +106,12 @@ public class Road {
 
     // Getter for incoming lanes
     public List<Lane> getIncomingLanes() {
-        return incomingLanes;
+        return Collections.unmodifiableList(incomingLanes);
     }
 
     // Getter for outgoing lanes
     public List<Lane> getOutgoingLanes() {
-        return outgoingLanes;
+        return Collections.unmodifiableList(outgoingLanes);
     }
 
     // Getter for pedestrian crossing

--- a/src/main/java/com/trafficlightsimulator/model/TrafficLightGroup.java
+++ b/src/main/java/com/trafficlightsimulator/model/TrafficLightGroup.java
@@ -115,7 +115,7 @@ public class TrafficLightGroup {
 
     // Getter for the list of traffic lights
     public List<TrafficLight> getLights() {
-        return lights;
+        return Collections.unmodifiableList(lights);
     }
 
     // Method to display the current state of each light in the group (for debugging)

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -1,5 +1,7 @@
 package com.trafficlightsimulator.model;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -57,8 +59,10 @@ class IntersectionTest {
         Road road = new Road(0.0, 1, 1);
         intersection.addRoad(road);
 
-        assertThrows(UnsupportedOperationException.class,
-                () -> intersection.getRoads().add(new Road(90.0, 1, 1)));
+        List<Road> roads = intersection.getRoads();
+        Road anotherRoad = new Road(90.0, 1, 1);
+
+        assertThrows(UnsupportedOperationException.class, () -> roads.add(anotherRoad));
 
         assertEquals(1, intersection.getRoads().size());
         assertSame(road, intersection.getRoads().get(0));

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -52,6 +52,19 @@ class IntersectionTest {
     }
 
     @Test
+    void getRoads_returnsUnmodifiableViewBackedByInternalRoads() {
+        Intersection intersection = new Intersection(2);
+        Road road = new Road(0.0, 1, 1);
+        intersection.addRoad(road);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> intersection.getRoads().add(new Road(90.0, 1, 1)));
+
+        assertEquals(1, intersection.getRoads().size());
+        assertSame(road, intersection.getRoads().get(0));
+    }
+
+    @Test
     void setNumberOfRoads_rejectsValueBelowCurrentRoadCount() {
         Intersection intersection = new Intersection(4);
         intersection.addRoad(new Road(0.0, 1, 1));

--- a/src/test/java/com/trafficlightsimulator/model/LaneTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/LaneTest.java
@@ -20,6 +20,19 @@ class LaneTest {
     }
 
     @Test
+    void getAllowedOutgoingLanes_returnsUnmodifiableView() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane outgoing = new Lane(Lane.Direction.OUTGOING);
+        incoming.addAllowedOutgoingLane(outgoing);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> incoming.getAllowedOutgoingLanes().add(new Lane(Lane.Direction.OUTGOING)));
+
+        assertEquals(1, incoming.getAllowedOutgoingLanes().size());
+        assertSame(outgoing, incoming.getAllowedOutgoingLanes().get(0));
+    }
+
+    @Test
     void addAllowedOutgoingLane_allowsIncomingToOutgoingLane() {
         Lane incoming = new Lane(Lane.Direction.INCOMING);
         Lane outgoing = new Lane(Lane.Direction.OUTGOING);

--- a/src/test/java/com/trafficlightsimulator/model/LaneTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/LaneTest.java
@@ -1,5 +1,7 @@
 package com.trafficlightsimulator.model;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,8 +27,10 @@ class LaneTest {
         Lane outgoing = new Lane(Lane.Direction.OUTGOING);
         incoming.addAllowedOutgoingLane(outgoing);
 
-        assertThrows(UnsupportedOperationException.class,
-                () -> incoming.getAllowedOutgoingLanes().add(new Lane(Lane.Direction.OUTGOING)));
+        List<Lane> allowedOutgoingLanes = incoming.getAllowedOutgoingLanes();
+        Lane anotherOutgoing = new Lane(Lane.Direction.OUTGOING);
+
+        assertThrows(UnsupportedOperationException.class, () -> allowedOutgoingLanes.add(anotherOutgoing));
 
         assertEquals(1, incoming.getAllowedOutgoingLanes().size());
         assertSame(outgoing, incoming.getAllowedOutgoingLanes().get(0));

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -85,6 +85,30 @@ class RoadTest {
     }
 
     @Test
+    void getIncomingLanes_returnsUnmodifiableView() {
+        Road road = new Road(0.0, 1, 1);
+        Lane originalLane = road.getIncomingLanes().get(0);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> road.getIncomingLanes().add(new Lane(Lane.Direction.INCOMING)));
+
+        assertEquals(1, road.getIncomingLanes().size());
+        assertSame(originalLane, road.getIncomingLanes().get(0));
+    }
+
+    @Test
+    void getOutgoingLanes_returnsUnmodifiableView() {
+        Road road = new Road(0.0, 1, 1);
+        Lane originalLane = road.getOutgoingLanes().get(0);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> road.getOutgoingLanes().clear());
+
+        assertEquals(1, road.getOutgoingLanes().size());
+        assertSame(originalLane, road.getOutgoingLanes().get(0));
+    }
+
+    @Test
     void setNumIncomingLanes_growthPreservesExistingLaneObjects() {
         Road road = new Road(0.0, 2, 1);
         Lane originalFirst = road.getIncomingLanes().get(0);

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -1,5 +1,7 @@
 package com.trafficlightsimulator.model;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -87,10 +89,11 @@ class RoadTest {
     @Test
     void getIncomingLanes_returnsUnmodifiableView() {
         Road road = new Road(0.0, 1, 1);
-        Lane originalLane = road.getIncomingLanes().get(0);
+        List<Lane> incomingLanes = road.getIncomingLanes();
+        Lane originalLane = incomingLanes.get(0);
+        Lane anotherIncoming = new Lane(Lane.Direction.INCOMING);
 
-        assertThrows(UnsupportedOperationException.class,
-                () -> road.getIncomingLanes().add(new Lane(Lane.Direction.INCOMING)));
+        assertThrows(UnsupportedOperationException.class, () -> incomingLanes.add(anotherIncoming));
 
         assertEquals(1, road.getIncomingLanes().size());
         assertSame(originalLane, road.getIncomingLanes().get(0));
@@ -99,10 +102,10 @@ class RoadTest {
     @Test
     void getOutgoingLanes_returnsUnmodifiableView() {
         Road road = new Road(0.0, 1, 1);
-        Lane originalLane = road.getOutgoingLanes().get(0);
+        List<Lane> outgoingLanes = road.getOutgoingLanes();
+        Lane originalLane = outgoingLanes.get(0);
 
-        assertThrows(UnsupportedOperationException.class,
-                () -> road.getOutgoingLanes().clear());
+        assertThrows(UnsupportedOperationException.class, outgoingLanes::clear);
 
         assertEquals(1, road.getOutgoingLanes().size());
         assertSame(originalLane, road.getOutgoingLanes().get(0));

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
@@ -22,6 +22,19 @@ class TrafficLightGroupTest {
     }
 
     @Test
+    void getLights_returnsUnmodifiableView() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        TrafficLight light = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
+        group.addTrafficLight(light);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> group.getLights().add(trafficLight(Direction.LEFT, Color.RED, State.ON)));
+
+        assertEquals(1, group.getLights().size());
+        assertSame(light, group.getLights().get(0));
+    }
+
+    @Test
     void removeTrafficLight_removesMembershipAndConfiguredIncompatibilities() {
         TrafficLightGroup group = new TrafficLightGroup();
         TrafficLight northbound = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
@@ -1,8 +1,9 @@
 package com.trafficlightsimulator.model;
 
-import org.junit.jupiter.api.Test;
-
+import java.util.List;
 import java.util.Set;
+
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -27,8 +28,10 @@ class TrafficLightGroupTest {
         TrafficLight light = trafficLight(Direction.STRAIGHT, Color.RED, State.ON);
         group.addTrafficLight(light);
 
-        assertThrows(UnsupportedOperationException.class,
-                () -> group.getLights().add(trafficLight(Direction.LEFT, Color.RED, State.ON)));
+        List<TrafficLight> lights = group.getLights();
+        TrafficLight anotherLight = trafficLight(Direction.LEFT, Color.RED, State.ON);
+
+        assertThrows(UnsupportedOperationException.class, () -> lights.add(anotherLight));
 
         assertEquals(1, group.getLights().size());
         assertSame(light, group.getLights().get(0));


### PR DESCRIPTION
### Motivation

- Harden model encapsulation so callers cannot mutate internal collections returned by getters and accidentally bypass validation/safety logic.
- Make backing collection fields final where appropriate to signal immutability of the container reference.
- Document the behavioral change and bump the pre-MVP snapshot version to reflect the API tightening.

### Description

- Return unmodifiable views from collection getters: `Intersection.getRoads()`, `Road.getIncomingLanes()`, `Road.getOutgoingLanes()`, `TrafficLightGroup.getLights()`, and `Lane.getAllowedOutgoingLanes()` now return `Collections.unmodifiableList(...)`.
- Make mutable backing lists `final` where applicable (`Intersection.roads`, `Road.incomingLanes` / `outgoingLanes`, `Lane.allowedOutgoingLanes`) so only model methods can mutate them.
- Add regression unit tests asserting that attempts to modify the returned collections throw `UnsupportedOperationException` (tests added to `IntersectionTest`, `RoadTest`, `TrafficLightGroupTest`, and `LaneTest`).
- Update project metadata and docs: bump development version to `0.8.0-SNAPSHOT` in `pom.xml`, add a `Model collection encapsulation` section to `README.md`, and record the change in `CHANGELOG.md`.

### Testing

- Compiled production sources with `javac -d /tmp/tls-classes $(find src/main/java -name '*.java')`, which succeeded.
- Attempted Maven test runs: `mvn -B test` failed due to a Maven Central `403 Forbidden` while resolving the JaCoCo plugin, and `mvn -o -B test` also failed because the plugin wasn’t already cached; therefore the JUnit test suite could not be executed in this environment.
- Added unit tests verify unmodifiable views by asserting `UnsupportedOperationException` on external mutation attempts (tests are present but not run due to the plugin resolution issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21924493948325a37d524446424caa)