### PR TITLE
Add contents read permission to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and analyze


### PR DESCRIPTION
## Summary
Added explicit `contents: read` permission to the GitHub Actions build workflow to follow security best practices and ensure the workflow has the minimum required permissions.

## Key Changes
- Added `permissions` section to the build workflow with `contents: read` permission
- This explicitly grants the workflow read access to repository contents, which is required for checking out code and analyzing the repository

## Implementation Details
The permission is scoped at the workflow level, applying to all jobs in the build workflow. This follows the principle of least privilege by explicitly declaring only the necessary permissions rather than relying on default permissions.

https://claude.ai/code/session_01QgtjSZ9TJc42EryKqcReHx