### PR TITLE
feat: add lane turn restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ the current `0.x` baseline.
 
 ### Fixed
 
+- Road-level turn restriction helpers now reject outbound lanes that do not
+  belong to the road being configured, preventing cross-road outbound lanes from
+  being stored as allowed turns.
+
 - Reconciled `PedestrianButton` and `PedestrianCrossing` light-group ownership so
   crossings own the pedestrian light group and constructor-supplied buttons are
   connected to that same group without allowing a later crossing to steal an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ the current `0.x` baseline.
 
 ### Added
 
+- `Lane.setAllowedOutgoingLanes(Collection<Lane>)` and
+  `Lane.validateOutgoingLaneAllowed(Lane)` to replace inbound-lane turn
+  restrictions atomically and reject illegal outbound turns with clear feedback.
+- `Road` helpers for inbound-to-outbound lane restrictions: `addAllowedTurn`,
+  `setAllowedTurns`, `getAllowedTurns`, `isTurnAllowed`, and
+  `validateTurnAllowed`.
+- Unit tests covering duplicate-safe allowed turns, replacement validation,
+  road-level restriction configuration, valid turn enforcement, and illegal-turn
+  rejection.
+
 - `PedestrianCrossing.ControlType` enum (`BUTTON_CONTROLLED`, `AUTOMATED`) to distinguish
   button-operated crossings from those controlled automatically by the simulation engine.
 - `PedestrianCrossing.getControlType()` to query a crossing's control mode.
@@ -71,6 +81,9 @@ the current `0.x` baseline.
   with `IllegalArgumentException`.
 
 ### Changed
+
+- Incremented the pre-MVP development version from `0.10.0-SNAPSHOT` to
+  `0.11.0-SNAPSHOT` for inbound-to-outbound lane turn restrictions.
 
 - Incremented the pre-MVP development version from `0.8.0-SNAPSHOT` to
   `0.9.0-SNAPSHOT` for the source package layering restructure.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ so each permitted turn appears only once. Before routing traffic, call
 `IllegalStateException`.
 
 `Road` provides road-level helpers for configuring and enforcing the same
-restrictions while ensuring the inbound lane belongs to that road. Use
-`Road.addAllowedTurn`, `Road.setAllowedTurns`, `Road.getAllowedTurns`,
-`Road.isTurnAllowed`, and `Road.validateTurnAllowed` to manage inbound-to-outbound
-movement rules across road lanes.
+restrictions while ensuring the inbound lane and outbound lane both belong to
+that road. Use `Road.addAllowedTurn`, `Road.setAllowedTurns`,
+`Road.getAllowedTurns`, `Road.isTurnAllowed`, and `Road.validateTurnAllowed` to
+manage inbound-to-outbound movement rules across road lanes.
 
 ## Traffic-light safety rules
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and configuration concerns.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.9.0-SNAPSHOT`
+- **Current development version:** `0.11.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Versioning policy
@@ -64,7 +64,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.9.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.11.0-SNAPSHOT.jar
 ```
 
 ### Resolving Maven Central 403 errors
@@ -119,6 +119,23 @@ routes through getters, but structural changes must go through the model methods
 such as `Intersection.addRoad`, `Road.setNumIncomingLanes`,
 `Road.setNumOutgoingLanes`, `TrafficLightGroup.addTrafficLight`, and
 `Lane.addAllowedOutgoingLane` so validation and safety rules remain enforced.
+
+
+## Lane turn restrictions
+
+Inbound `Lane` instances own the set of outbound lanes they may turn into. Use
+`Lane.addAllowedOutgoingLane` for incremental configuration or
+`Lane.setAllowedOutgoingLanes` to replace an inbound lane's complete restriction
+set. The getter returns a read-only view, and duplicate outbound lanes are ignored
+so each permitted turn appears only once. Before routing traffic, call
+`Lane.validateOutgoingLaneAllowed` to reject illegal turns with a clear
+`IllegalStateException`.
+
+`Road` provides road-level helpers for configuring and enforcing the same
+restrictions while ensuring the inbound lane belongs to that road. Use
+`Road.addAllowedTurn`, `Road.setAllowedTurns`, `Road.getAllowedTurns`,
+`Road.isTurnAllowed`, and `Road.validateTurnAllowed` to manage inbound-to-outbound
+movement rules across road lanes.
 
 ## Traffic-light safety rules
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/model/Lane.java
+++ b/src/main/java/com/trafficlightsimulator/model/Lane.java
@@ -1,6 +1,7 @@
 package com.trafficlightsimulator.model;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -27,14 +28,26 @@ public class Lane {
 
     // Method to add an allowed outgoing lane (only applicable for incoming lanes)
     public void addAllowedOutgoingLane(Lane lane) {
-        if (lane == null) {
-            throw new IllegalArgumentException("Allowed outgoing lane must not be null.");
-        }
-        if (this.direction == Direction.INCOMING && lane.direction == Direction.OUTGOING) {
+        validateAllowedOutgoingLane(lane);
+        if (!allowedOutgoingLanes.contains(lane)) {
             allowedOutgoingLanes.add(lane);
             logger.log(Level.INFO, "Added allowed outgoing lane: {0}", lane);
-        } else {
-            throw new IllegalArgumentException("Only incoming lanes can have allowed outgoing lanes, and only outgoing lanes can be added.");
+        }
+    }
+
+    // Method to replace all allowed outgoing lanes for this inbound lane
+    public void setAllowedOutgoingLanes(Collection<Lane> lanes) {
+        if (lanes == null) {
+            throw new IllegalArgumentException("Allowed outgoing lanes must not be null.");
+        }
+        List<Lane> replacementLanes = new ArrayList<>(lanes);
+        for (Lane lane : replacementLanes) {
+            validateAllowedOutgoingLane(lane);
+        }
+
+        allowedOutgoingLanes.clear();
+        for (Lane lane : replacementLanes) {
+            addAllowedOutgoingLane(lane);
         }
     }
 
@@ -51,6 +64,28 @@ public class Lane {
     // Utility method to check if a lane is an allowed outgoing lane
     public boolean isAllowedOutgoingLane(Lane lane) {
         return allowedOutgoingLanes.contains(lane);
+    }
+
+    // Method to enforce turn restrictions before traffic is routed to an outgoing lane
+    public void validateOutgoingLaneAllowed(Lane lane) {
+        if (lane == null) {
+            throw new IllegalArgumentException("Outgoing lane must not be null.");
+        }
+        if (direction != Direction.INCOMING) {
+            throw new IllegalStateException("Only incoming lanes can validate outgoing turn restrictions.");
+        }
+        if (!isAllowedOutgoingLane(lane)) {
+            throw new IllegalStateException("Illegal turn: outbound lane is not permitted for this inbound lane.");
+        }
+    }
+
+    private void validateAllowedOutgoingLane(Lane lane) {
+        if (lane == null) {
+            throw new IllegalArgumentException("Allowed outgoing lane must not be null.");
+        }
+        if (this.direction != Direction.INCOMING || lane.direction != Direction.OUTGOING) {
+            throw new IllegalArgumentException("Only incoming lanes can have allowed outgoing lanes, and only outgoing lanes can be added.");
+        }
     }
 
     // Method to display lane information (for debugging purposes)

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -219,6 +219,9 @@ public class Road {
         if (outboundLane.getDirection() != Lane.Direction.OUTGOING) {
             throw new IllegalArgumentException("Turn restrictions must target an outbound lane.");
         }
+        if (!outgoingLanes.contains(outboundLane)) {
+            throw new IllegalArgumentException("Outbound lane must belong to this road.");
+        }
     }
 
     // Getter for pedestrian crossing

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -3,6 +3,7 @@ package com.trafficlightsimulator.model;
 import com.trafficlightsimulator.config.RoadLimits;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -135,6 +136,89 @@ public class Road {
     // Getter for outgoing lanes
     public List<Lane> getOutgoingLanes() {
         return Collections.unmodifiableList(outgoingLanes);
+    }
+
+
+    // Associate one inbound lane with an allowable outbound lane.
+    public void addAllowedTurn(Lane inboundLane, Lane outboundLane) {
+        validateInboundLaneMembership(inboundLane);
+        validateOutboundLane(outboundLane);
+        inboundLane.addAllowedOutgoingLane(outboundLane);
+        logger.log(Level.INFO, "Allowed turn configured from inbound lane {0} to outbound lane {1}",
+                new Object[] { inboundLane, outboundLane });
+    }
+
+    // Replace all allowable outbound lanes for an inbound lane.
+    public void setAllowedTurns(Lane inboundLane, Collection<Lane> outboundLanes) {
+        validateInboundLaneMembership(inboundLane);
+        if (outboundLanes == null) {
+            throw new IllegalArgumentException("Allowed outbound lanes must not be null.");
+        }
+        for (Lane outboundLane : outboundLanes) {
+            validateOutboundLane(outboundLane);
+        }
+        inboundLane.setAllowedOutgoingLanes(outboundLanes);
+        logger.log(Level.INFO, "Allowed turns replaced for inbound lane {0}", inboundLane);
+    }
+
+    // Associate one inbound lane index with one of this road's outbound lane indexes.
+    public void addAllowedTurn(int inboundLaneIndex, int outboundLaneIndex) {
+        addAllowedTurn(getIncomingLaneAt(inboundLaneIndex), getOutgoingLaneAt(outboundLaneIndex));
+    }
+
+    // Retrieve allowable outbound lanes for a road-owned inbound lane.
+    public List<Lane> getAllowedTurns(Lane inboundLane) {
+        validateInboundLaneMembership(inboundLane);
+        return inboundLane.getAllowedOutgoingLanes();
+    }
+
+    // Check whether the configured restrictions permit a turn.
+    public boolean isTurnAllowed(Lane inboundLane, Lane outboundLane) {
+        validateInboundLaneMembership(inboundLane);
+        validateOutboundLane(outboundLane);
+        return inboundLane.isAllowedOutgoingLane(outboundLane);
+    }
+
+    // Enforce configured restrictions before routing traffic to an outbound lane.
+    public void validateTurnAllowed(Lane inboundLane, Lane outboundLane) {
+        validateInboundLaneMembership(inboundLane);
+        validateOutboundLane(outboundLane);
+        inboundLane.validateOutgoingLaneAllowed(outboundLane);
+    }
+
+    private Lane getIncomingLaneAt(int inboundLaneIndex) {
+        if (inboundLaneIndex < 0 || inboundLaneIndex >= incomingLanes.size()) {
+            throw new IndexOutOfBoundsException("Inbound lane index is outside this road's incoming lane range.");
+        }
+        return incomingLanes.get(inboundLaneIndex);
+    }
+
+    private Lane getOutgoingLaneAt(int outboundLaneIndex) {
+        if (outboundLaneIndex < 0 || outboundLaneIndex >= outgoingLanes.size()) {
+            throw new IndexOutOfBoundsException("Outbound lane index is outside this road's outgoing lane range.");
+        }
+        return outgoingLanes.get(outboundLaneIndex);
+    }
+
+    private void validateInboundLaneMembership(Lane inboundLane) {
+        if (inboundLane == null) {
+            throw new IllegalArgumentException("Inbound lane must not be null.");
+        }
+        if (inboundLane.getDirection() != Lane.Direction.INCOMING) {
+            throw new IllegalArgumentException("Turn restrictions must start from an inbound lane.");
+        }
+        if (!incomingLanes.contains(inboundLane)) {
+            throw new IllegalArgumentException("Inbound lane must belong to this road.");
+        }
+    }
+
+    private void validateOutboundLane(Lane outboundLane) {
+        if (outboundLane == null) {
+            throw new IllegalArgumentException("Outbound lane must not be null.");
+        }
+        if (outboundLane.getDirection() != Lane.Direction.OUTGOING) {
+            throw new IllegalArgumentException("Turn restrictions must target an outbound lane.");
+        }
     }
 
     // Getter for pedestrian crossing

--- a/src/test/java/com/trafficlightsimulator/model/LaneTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/LaneTest.java
@@ -85,4 +85,74 @@ class LaneTest {
         assertFalse(incoming.isAllowedOutgoingLane(outgoing));
         assertFalse(incoming.isAllowedOutgoingLane(null));
     }
+
+
+    @Test
+    void addAllowedOutgoingLane_ignoresDuplicateLane() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane outgoing = new Lane(Lane.Direction.OUTGOING);
+
+        incoming.addAllowedOutgoingLane(outgoing);
+        incoming.addAllowedOutgoingLane(outgoing);
+
+        assertEquals(1, incoming.getAllowedOutgoingLanes().size());
+        assertSame(outgoing, incoming.getAllowedOutgoingLanes().get(0));
+    }
+
+    @Test
+    void setAllowedOutgoingLanes_replacesExistingRestrictionsAndDeduplicates() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane removedOutgoing = new Lane(Lane.Direction.OUTGOING);
+        Lane allowedOutgoing = new Lane(Lane.Direction.OUTGOING);
+        incoming.addAllowedOutgoingLane(removedOutgoing);
+
+        incoming.setAllowedOutgoingLanes(List.of(allowedOutgoing, allowedOutgoing));
+
+        assertEquals(1, incoming.getAllowedOutgoingLanes().size());
+        assertSame(allowedOutgoing, incoming.getAllowedOutgoingLanes().get(0));
+        assertTrue(incoming.isAllowedOutgoingLane(allowedOutgoing));
+        assertFalse(incoming.isAllowedOutgoingLane(removedOutgoing));
+    }
+
+    @Test
+    void setAllowedOutgoingLanes_rejectsInvalidCollectionWithoutChangingExistingRestrictions() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane existingOutgoing = new Lane(Lane.Direction.OUTGOING);
+        Lane invalidIncoming = new Lane(Lane.Direction.INCOMING);
+        incoming.addAllowedOutgoingLane(existingOutgoing);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> incoming.setAllowedOutgoingLanes(List.of(invalidIncoming)));
+
+        assertEquals(1, incoming.getAllowedOutgoingLanes().size());
+        assertSame(existingOutgoing, incoming.getAllowedOutgoingLanes().get(0));
+    }
+
+    @Test
+    void setAllowedOutgoingLanes_rejectsNullCollection() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+
+        assertThrows(IllegalArgumentException.class, () -> incoming.setAllowedOutgoingLanes(null));
+    }
+
+    @Test
+    void validateOutgoingLaneAllowed_allowsPermittedTurn() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane outgoing = new Lane(Lane.Direction.OUTGOING);
+        incoming.addAllowedOutgoingLane(outgoing);
+
+        assertDoesNotThrow(() -> incoming.validateOutgoingLaneAllowed(outgoing));
+    }
+
+    @Test
+    void validateOutgoingLaneAllowed_preventsIllegalTurnWithClearFeedback() {
+        Lane incoming = new Lane(Lane.Direction.INCOMING);
+        Lane outgoing = new Lane(Lane.Direction.OUTGOING);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> incoming.validateOutgoingLaneAllowed(outgoing));
+
+        assertTrue(exception.getMessage().contains("Illegal turn"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/LaneTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/LaneTest.java
@@ -120,9 +120,10 @@ class LaneTest {
         Lane existingOutgoing = new Lane(Lane.Direction.OUTGOING);
         Lane invalidIncoming = new Lane(Lane.Direction.INCOMING);
         incoming.addAllowedOutgoingLane(existingOutgoing);
+        List<Lane> invalidOutgoingLanes = List.of(invalidIncoming);
 
         assertThrows(IllegalArgumentException.class,
-                () -> incoming.setAllowedOutgoingLanes(List.of(invalidIncoming)));
+                () -> incoming.setAllowedOutgoingLanes(invalidOutgoingLanes));
 
         assertEquals(1, incoming.getAllowedOutgoingLanes().size());
         assertSame(existingOutgoing, incoming.getAllowedOutgoingLanes().get(0));

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -282,17 +282,32 @@ class RoadTest {
     void addAllowedTurn_rejectsInboundLaneFromAnotherRoad() {
         Road road = new Road(0.0, 1, 1);
         Road otherRoad = new Road(90.0, 1, 1);
+        Lane foreignInboundLane = otherRoad.getIncomingLanes().get(0);
+        Lane ownedOutboundLane = road.getOutgoingLanes().get(0);
 
         assertThrows(IllegalArgumentException.class,
-                () -> road.addAllowedTurn(otherRoad.getIncomingLanes().get(0), road.getOutgoingLanes().get(0)));
+                () -> road.addAllowedTurn(foreignInboundLane, ownedOutboundLane));
+    }
+
+    @Test
+    void addAllowedTurn_rejectsOutboundLaneFromAnotherRoad() {
+        Road road = new Road(0.0, 1, 1);
+        Road otherRoad = new Road(90.0, 1, 1);
+        Lane ownedInboundLane = road.getIncomingLanes().get(0);
+        Lane foreignOutboundLane = otherRoad.getOutgoingLanes().get(0);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> road.addAllowedTurn(ownedInboundLane, foreignOutboundLane));
     }
 
     @Test
     void addAllowedTurn_rejectsNonOutboundTarget() {
         Road road = new Road(0.0, 2, 1);
+        Lane ownedInboundLane = road.getIncomingLanes().get(0);
+        Lane nonOutboundLane = road.getIncomingLanes().get(1);
 
         assertThrows(IllegalArgumentException.class,
-                () -> road.addAllowedTurn(road.getIncomingLanes().get(0), road.getIncomingLanes().get(1)));
+                () -> road.addAllowedTurn(ownedInboundLane, nonOutboundLane));
     }
 
     @Test

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -219,4 +219,88 @@ class RoadTest {
 
         assertSame(second, road.getPedestrianCrossing());
     }
+
+
+    @Test
+    void addAllowedTurnByLane_configuresInboundToOutboundRestriction() {
+        Road road = new Road(0.0, 2, 2);
+        Lane inbound = road.getIncomingLanes().get(0);
+        Lane outbound = road.getOutgoingLanes().get(1);
+
+        road.addAllowedTurn(inbound, outbound);
+
+        assertTrue(road.isTurnAllowed(inbound, outbound));
+        assertSame(outbound, road.getAllowedTurns(inbound).get(0));
+    }
+
+    @Test
+    void addAllowedTurnByIndex_configuresInboundToSameRoadOutboundRestriction() {
+        Road road = new Road(0.0, 2, 2);
+
+        road.addAllowedTurn(1, 0);
+
+        assertTrue(road.isTurnAllowed(road.getIncomingLanes().get(1), road.getOutgoingLanes().get(0)));
+    }
+
+    @Test
+    void setAllowedTurns_replacesPermittedOutboundLanesForInboundLane() {
+        Road road = new Road(0.0, 1, 2);
+        Lane inbound = road.getIncomingLanes().get(0);
+        Lane removedOutbound = road.getOutgoingLanes().get(0);
+        Lane allowedOutbound = road.getOutgoingLanes().get(1);
+        road.addAllowedTurn(inbound, removedOutbound);
+
+        road.setAllowedTurns(inbound, List.of(allowedOutbound));
+
+        assertFalse(road.isTurnAllowed(inbound, removedOutbound));
+        assertTrue(road.isTurnAllowed(inbound, allowedOutbound));
+    }
+
+    @Test
+    void validateTurnAllowed_allowsPermittedTurn() {
+        Road road = new Road(0.0, 1, 1);
+        Lane inbound = road.getIncomingLanes().get(0);
+        Lane outbound = road.getOutgoingLanes().get(0);
+        road.addAllowedTurn(inbound, outbound);
+
+        assertDoesNotThrow(() -> road.validateTurnAllowed(inbound, outbound));
+    }
+
+    @Test
+    void validateTurnAllowed_preventsIllegalTurnWithClearFeedback() {
+        Road road = new Road(0.0, 1, 2);
+        Lane inbound = road.getIncomingLanes().get(0);
+        Lane outbound = road.getOutgoingLanes().get(1);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> road.validateTurnAllowed(inbound, outbound));
+
+        assertTrue(exception.getMessage().contains("Illegal turn"));
+    }
+
+    @Test
+    void addAllowedTurn_rejectsInboundLaneFromAnotherRoad() {
+        Road road = new Road(0.0, 1, 1);
+        Road otherRoad = new Road(90.0, 1, 1);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> road.addAllowedTurn(otherRoad.getIncomingLanes().get(0), road.getOutgoingLanes().get(0)));
+    }
+
+    @Test
+    void addAllowedTurn_rejectsNonOutboundTarget() {
+        Road road = new Road(0.0, 2, 1);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> road.addAllowedTurn(road.getIncomingLanes().get(0), road.getIncomingLanes().get(1)));
+    }
+
+    @Test
+    void addAllowedTurnByIndex_rejectsOutOfRangeIndexes() {
+        Road road = new Road(0.0, 1, 1);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> road.addAllowedTurn(-1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> road.addAllowedTurn(0, 1));
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Provide a model-level way to express permitted turns from an inbound lane to one or more outbound lanes so routing and enforcement can prevent illegal turns. 
- Expose road-level helpers that operate safely on lanes owned by a `Road` so callers can configure and validate allowed turns without manipulating lane internals directly.

### Description

- Added inbound-lane turn restriction APIs to `Lane`: `addAllowedOutgoingLane(Lane)`, `setAllowedOutgoingLanes(Collection<Lane>)`, `isAllowedOutgoingLane(Lane)`, and `validateOutgoingLaneAllowed(Lane)`, and internal validation via `validateAllowedOutgoingLane(Lane)`; `addAllowedOutgoingLane` now ignores duplicates.
- Added road-level helpers to `Road`: `addAllowedTurn(Lane,Lane)`, `setAllowedTurns(Lane,Collection<Lane>)`, `addAllowedTurn(int,int)`, `getAllowedTurns(Lane)`, `isTurnAllowed(Lane,Lane)`, and `validateTurnAllowed(Lane,Lane)`, plus index-based accessors and membership validators to ensure inbound lanes belong to the road.
- Added unit tests covering duplicate-safe allowed turns, atomic replacement validation, valid-turn enforcement, illegal-turn rejection with clear messages, road-level configuration, index bounds and cross-road rejection.
- Updated documentation and metadata: added a `Lane turn restrictions` section to `README.md`, updated `CHANGELOG.md` with the new features, and bumped the project development version to `0.11.0-SNAPSHOT` in `pom.xml` and README.

### Testing

- Successfully compiled the main sources with `javac --release 17 -d /tmp/tls-classes $(find src/main/java -name '*.java' | sort)`, which completed without errors.
- Attempted full Maven verification with `mvn -B verify`, but the run failed during plugin resolution because Maven Central returned `403 Forbidden` while resolving `org.jacoco:jacoco-maven-plugin:0.8.12`, so the test phase could not be executed end-to-end under Maven in this environment.
- Unit tests were added under `src/test/java` (for `Lane` and `Road`) and will execute normally when `mvn -B verify` can resolve build plugins and dependencies; compilation-only smoke checks indicate the new code is type-correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a222bfff8f883258327cefbcf0b6c33)