### PR TITLE
feat(model): improve diagnostics and identity semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ the current `0.x` baseline.
 
 ### Added
 
+- Readable `toString()` implementations plus explicit identity-based `equals()`
+  and `hashCode()` methods on core model entities (`Intersection`, `Road`,
+  `Lane`, `TrafficLight`, `TrafficLightGroup`, `PedestrianCrossing`, and
+  `PedestrianButton`).
+- Unit coverage for model entity identity semantics and readable diagnostic
+  string output.
+
+### Added
+
 - Javadoc on all public classes and methods across `model`, `engine`, `config`,
   and `app` packages, covering intent, invariants, parameters, return values,
   and exceptions thrown.
@@ -106,6 +115,11 @@ the current `0.x` baseline.
   with `IllegalArgumentException`.
 
 ### Changed
+
+- Bumped the pre-MVP development version from `0.12.0-SNAPSHOT` to
+  `0.13.0-SNAPSHOT` for the model diagnostics and equality-semantics update.
+- Reduced routine model and initialization logging from `INFO` to `FINE` while
+  keeping warning paths at `WARNING`, so normal runs no longer flood info logs.
 
 - Renamed the former SonarCloud-only workflow to `ci.yml` and split it into a
   fork-safe Maven build/test job plus a separately guarded SonarQube Cloud job.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ until a stable `1.0.0` release is declared.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.12.0-SNAPSHOT`
+- **Current development version:** `0.13.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Architecture overview
@@ -38,9 +38,10 @@ com.trafficlightsimulator
 
 - Collection getters return read-only views. Structural changes must go
   through typed mutator methods so validation and safety rules stay enforced.
-- `TrafficLight` uses Java object identity for equality. This lets
-  `TrafficLightGroup` incompatibility rules target specific physical lights
-  rather than value-equal copies.
+- Core model entities (`Intersection`, `Road`, `Lane`, `TrafficLight`,
+  `TrafficLightGroup`, `PedestrianCrossing`, and `PedestrianButton`) use
+  Java object identity for equality. This lets simulator relationships target
+  specific physical objects rather than value-equal copies.
 - A light is considered *active* when its colour is `GREEN` and its state
   is `ON`. Incompatibility checks fire only on activation, keeping the model
   simple for non-conflicting state transitions.
@@ -98,7 +99,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.12.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.13.0-SNAPSHOT.jar
 ```
 
 ## Generating API documentation
@@ -155,15 +156,25 @@ Inbound `Lane` instances own the set of outbound lanes they may turn into. Use
 `Lane.addAllowedOutgoingLane` for incremental configuration or
 `Lane.setAllowedOutgoingLanes` to replace an inbound lane's complete restriction
 set. The getter returns a read-only view, and duplicate outbound lanes are ignored
-so each permitted turn appears only once. Before routing traffic, call
-`Lane.validateOutgoingLaneAllowed` to reject illegal turns with a clear
-`IllegalStateException`.
+so each permitted turn appears only once. Lane membership is identity-based: two
+lanes with the same direction are still different physical lanes unless they are
+the same object. Before routing traffic, call `Lane.validateOutgoingLaneAllowed`
+to reject illegal turns with a clear `IllegalStateException`.
 
 `Road` provides road-level helpers for configuring and enforcing the same
 restrictions while ensuring the inbound lane and outbound lane both belong to
 that road. Use `Road.addAllowedTurn`, `Road.setAllowedTurns`,
 `Road.getAllowedTurns`, `Road.isTurnAllowed`, and `Road.validateTurnAllowed` to
 manage inbound-to-outbound movement rules across road lanes.
+
+## Model logging and diagnostics
+
+Routine model mutations such as setter calls, adding lanes/lights, and configuring
+turn or incompatibility relationships log at `FINE` rather than `INFO` so normal
+simulation runs are not noisy by default. Warnings remain reserved for skipped or
+invalid state changes. Each core model entity also provides a concise `toString()`
+summary so diagnostic logs show useful object details instead of JVM identity
+strings.
 
 ## Traffic-light safety rules
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/engine/TrafficLightSimulationEngine.java
+++ b/src/main/java/com/trafficlightsimulator/engine/TrafficLightSimulationEngine.java
@@ -37,7 +37,7 @@ public class TrafficLightSimulationEngine {
             TrafficLightGroup lightGroup = road.getIncomingLanesTrafficLightGroup();
             if (lightGroup != null) {
                 lightGroup.setAllLightsState(State.OFF);
-                logger.log(Level.INFO, "Initialized traffic light group for road: {0}", road);
+                logger.log(Level.FINE, "Initialized traffic light group for road: {0}", road);
             }
         }
     }
@@ -50,7 +50,7 @@ public class TrafficLightSimulationEngine {
             TrafficLightGroup pedestrianLightGroup = crossing.getPedestrianLightGroup();
             if (pedestrianLightGroup != null) {
                 pedestrianLightGroup.setAllLightsState(State.OFF);
-                logger.log(Level.INFO, "Initialized pedestrian light group for crossing: {0}", crossing);
+                logger.log(Level.FINE, "Initialized pedestrian light group for crossing: {0}", crossing);
             }
         }
     }
@@ -59,13 +59,13 @@ public class TrafficLightSimulationEngine {
      * Displays the current intersection status for diagnostics.
      */
     public void displayIntersectionStatus() {
-        logger.log(Level.INFO, "Intersection Status:");
+        logger.log(Level.INFO, "Intersection status: {0}", intersection);
         for (Road road : intersection.getRoads()) {
-            logger.log(Level.INFO, "Road:");
+            logger.log(Level.INFO, "Road status: {0}", road);
             road.displayLaneInfo();
 
             if (road.hasPedestrianCrossing()) {
-                logger.log(Level.INFO, "Pedestrian Crossing:");
+                logger.log(Level.INFO, "Pedestrian crossing status: {0}", road.getPedestrianCrossing());
                 road.getPedestrianCrossing().displayCrossingStatus();
             }
         }

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -63,7 +63,7 @@ public class Intersection {
                     "Number of roads cannot be less than the number of roads already added: " + roads.size());
         }
         this.numberOfRoads = numberOfRoads;
-        logger.log(Level.INFO, "Number of roads set to: {0}", numberOfRoads);
+        logger.log(Level.FINE, "Number of roads set to: {0}", numberOfRoads);
     }
 
     /**
@@ -82,7 +82,7 @@ public class Intersection {
             throw new IllegalStateException("Cannot add more roads than the specified number: " + numberOfRoads);
         }
         roads.add(road);
-        logger.log(Level.INFO, "Added road to intersection. Total roads now: {0}", roads.size());
+        logger.log(Level.FINE, "Added road to intersection. Total roads now: {0}", roads.size());
     }
 
     /**
@@ -152,7 +152,7 @@ public class Intersection {
         if (secondGroup != firstGroup) {
             secondGroup.addIncompatibleLights(secondLight, firstLight);
         }
-        logger.log(Level.INFO, "Configured incompatible traffic lights for intersection: {0} <-> {1}",
+        logger.log(Level.FINE, "Configured incompatible traffic lights for intersection: {0} <-> {1}",
                 new Object[]{firstLight, secondLight});
     }
 
@@ -189,7 +189,7 @@ public class Intersection {
             TrafficLightGroup lightGroup = road.getIncomingLanesTrafficLightGroup();
             if (lightGroup != null) {
                 lightGroup.setAllLightsState(State.OFF);
-                logger.log(Level.INFO, "Initialized traffic light group for road: {0}", road);
+                logger.log(Level.FINE, "Initialized traffic light group for road: {0}", road);
             }
         }
     }
@@ -204,7 +204,7 @@ public class Intersection {
             TrafficLightGroup pedestrianLightGroup = crossing.getPedestrianLightGroup();
             if (pedestrianLightGroup != null) {
                 pedestrianLightGroup.setAllLightsState(State.OFF);
-                logger.log(Level.INFO, "Initialized pedestrian light group for crossing: {0}", crossing);
+                logger.log(Level.FINE, "Initialized pedestrian light group for crossing: {0}", crossing);
             }
         }
     }
@@ -218,7 +218,7 @@ public class Intersection {
     public boolean isIntersectionSetupComplete() {
         boolean isComplete = roads.size() == numberOfRoads;
         if (isComplete) {
-            logger.log(Level.INFO, "Intersection setup is complete with {0} roads.", roads.size());
+            logger.log(Level.FINE, "Intersection setup is complete with {0} roads.", roads.size());
         } else {
             logger.log(Level.WARNING, "Intersection setup is incomplete. Only {0} of {1} roads added.", new Object[]{roads.size(), numberOfRoads});
         }
@@ -230,13 +230,11 @@ public class Intersection {
      * intersection for diagnostic purposes.
      */
     public void displayIntersectionStatus() {
-        logger.log(Level.INFO, "Intersection Status:");
+        logger.log(Level.FINE, "{0}", this);
         for (Road road : roads) {
-            logger.log(Level.INFO, "Road:");
             road.displayLaneInfo();
 
             if (road.hasPedestrianCrossing()) {
-                logger.log(Level.INFO, "Pedestrian Crossing:");
                 road.getPedestrianCrossing().displayCrossingStatus();
             }
         }
@@ -253,4 +251,41 @@ public class Intersection {
         }
         return null;
     }
+
+    /**
+     * Returns a compact diagnostic representation of this intersection.
+     *
+     * @return readable intersection summary
+     */
+    @Override
+    public String toString() {
+        return "Intersection{"
+                + "configuredRoadCapacity=" + numberOfRoads
+                + ", roadCount=" + roads.size()
+                + ", setupComplete=" + (roads.size() == numberOfRoads)
+                + '}';
+    }
+
+    /**
+     * Intersections model physical junction instances, so equality is
+     * intentionally based on object identity rather than matching road lists.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same intersection
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/main/java/com/trafficlightsimulator/model/Lane.java
+++ b/src/main/java/com/trafficlightsimulator/model/Lane.java
@@ -57,7 +57,7 @@ public class Lane {
         validateAllowedOutgoingLane(lane);
         if (!allowedOutgoingLanes.contains(lane)) {
             allowedOutgoingLanes.add(lane);
-            logger.log(Level.INFO, "Added allowed outgoing lane: {0}", lane);
+            logger.log(Level.FINE, "Added allowed outgoing lane: {0}", lane);
         }
     }
 
@@ -145,11 +145,10 @@ public class Lane {
      * diagnostic purposes.
      */
     public void displayLaneInfo() {
-        logger.log(Level.INFO, "Lane Direction: {0}", direction);
+        logger.log(Level.FINE, "{0}", this);
         if (direction == Direction.INCOMING) {
-            logger.log(Level.INFO, "Allowed Outgoing Lanes: {0}", allowedOutgoingLanes.size());
             for (Lane outgoingLane : allowedOutgoingLanes) {
-                logger.log(Level.INFO, "Allowed Outgoing Lane: {0}", outgoingLane.getDirection());
+                logger.log(Level.FINE, "Allowed outgoing lane: {0}", outgoingLane);
             }
         }
     }
@@ -162,4 +161,40 @@ public class Lane {
             throw new IllegalArgumentException("Only incoming lanes can have allowed outgoing lanes, and only outgoing lanes can be added.");
         }
     }
+
+    /**
+     * Returns a compact diagnostic representation of this lane.
+     *
+     * @return readable lane summary
+     */
+    @Override
+    public String toString() {
+        return "Lane{"
+                + "direction=" + direction
+                + ", allowedOutgoingLaneCount=" + allowedOutgoingLanes.size()
+                + '}';
+    }
+
+    /**
+     * Lanes model physical lane instances, so equality is intentionally based
+     * on object identity rather than direction or configured turns.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same lane
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/main/java/com/trafficlightsimulator/model/PedestrianButton.java
+++ b/src/main/java/com/trafficlightsimulator/model/PedestrianButton.java
@@ -86,4 +86,40 @@ public class PedestrianButton {
         this.crossingAttachment = crossingAttachment;
         this.pedestrianLightGroup = pedestrianLightGroup;
     }
+
+    /**
+     * Returns a compact diagnostic representation of this button.
+     *
+     * @return readable pedestrian-button summary
+     */
+    @Override
+    public String toString() {
+        return "PedestrianButton{"
+                + "pressed=" + pressed
+                + ", attached=" + (crossingAttachment != null)
+                + '}';
+    }
+
+    /**
+     * Pedestrian buttons model physical push-button instances, so equality is
+     * intentionally based on object identity.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same button
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/main/java/com/trafficlightsimulator/model/PedestrianCrossing.java
+++ b/src/main/java/com/trafficlightsimulator/model/PedestrianCrossing.java
@@ -80,7 +80,7 @@ public class PedestrianCrossing {
     public void addPedestrianLight(TrafficLight light) {
         if (light != null && light.getType() == TrafficLight.Type.PEDESTRIAN) {
             pedestrianLightGroup.addTrafficLight(light);
-            logger.log(Level.INFO, "Added pedestrian light: {0}", light);
+            logger.log(Level.FINE, "Added pedestrian light: {0}", light);
         }
     }
 
@@ -130,7 +130,7 @@ public class PedestrianCrossing {
     public void activate() {
         pedestrianLightGroup.setAllLightsState(State.ON);
         pedestrianLightGroup.setAllLightsColor(Color.GREEN);
-        logger.log(Level.INFO, "Pedestrian crossing activated.");
+        logger.log(Level.FINE, "Pedestrian crossing activated.");
     }
 
     /**
@@ -140,7 +140,7 @@ public class PedestrianCrossing {
     public void deactivate() {
         pedestrianLightGroup.setAllLightsColor(Color.RED);
         pedestrianLightGroup.setAllLightsState(State.ON);
-        logger.log(Level.INFO, "Pedestrian crossing deactivated.");
+        logger.log(Level.FINE, "Pedestrian crossing deactivated.");
     }
 
     /**
@@ -177,7 +177,7 @@ public class PedestrianCrossing {
      * Logs the light states and button pressed status for diagnostic purposes.
      */
     public void displayCrossingStatus() {
-        logger.log(Level.INFO, "Pedestrian Crossing Status:");
+        logger.log(Level.FINE, "{0}", this);
         pedestrianLightGroup.displayGroupStatus();
         logButtonStatus(buttonAtStart, "Start");
         logButtonStatus(buttonAtEnd, "End");
@@ -196,14 +196,51 @@ public class PedestrianCrossing {
     private void resetButton(PedestrianButton button, String location) {
         if (button != null) {
             button.reset();
-            logger.log(Level.INFO, "Reset button at {0} of crossing.", location);
+            logger.log(Level.FINE, "Reset button at {0} of crossing.", location);
         }
     }
 
     private void logButtonStatus(PedestrianButton button, String location) {
         if (button != null) {
-            logger.log(Level.INFO, "Button at {0}: {1}",
-                    new Object[]{location, button.isPressed() ? "Pressed" : "Not Pressed"});
+            logger.log(Level.FINE, "Button at {0}: {1}", new Object[]{location, button});
         }
     }
+
+    /**
+     * Returns a compact diagnostic representation of this crossing.
+     *
+     * @return readable pedestrian-crossing summary
+     */
+    @Override
+    public String toString() {
+        return "PedestrianCrossing{"
+                + "controlType=" + controlType
+                + ", lightCount=" + pedestrianLightGroup.getLights().size()
+                + ", crossingRequested=" + isCrossingRequested()
+                + ", active=" + isActive()
+                + '}';
+    }
+
+    /**
+     * Pedestrian crossings model physical crossing instances, so equality is
+     * intentionally based on object identity.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same crossing
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -74,7 +74,7 @@ public class Road {
             throw new IllegalArgumentException("Angle must be between 0 and 360 degrees.");
         }
         this.angle = angle;
-        logger.log(Level.INFO, "Angle for road set to: {0} degrees", angle);
+        logger.log(Level.FINE, "Angle for road set to: {0} degrees", angle);
     }
 
     /**
@@ -108,7 +108,7 @@ public class Road {
             this.incomingLanes.subList(numIncomingLanes, current).clear();
         }
         this.numIncomingLanes = numIncomingLanes;
-        logger.log(Level.INFO, "Number of incoming lanes set to: {0}", numIncomingLanes);
+        logger.log(Level.FINE, "Number of incoming lanes set to: {0}", numIncomingLanes);
     }
 
     /**
@@ -141,7 +141,7 @@ public class Road {
             this.outgoingLanes.subList(numOutgoingLanes, current).clear();
         }
         this.numOutgoingLanes = numOutgoingLanes;
-        logger.log(Level.INFO, "Number of outgoing lanes set to: {0}", numOutgoingLanes);
+        logger.log(Level.FINE, "Number of outgoing lanes set to: {0}", numOutgoingLanes);
     }
 
     /**
@@ -186,7 +186,7 @@ public class Road {
      */
     public void setPedestrianCrossing(PedestrianCrossing pedestrianCrossing) {
         this.pedestrianCrossing = pedestrianCrossing;
-        logger.log(Level.INFO, "Pedestrian crossing set for the road: {0}", pedestrianCrossing);
+        logger.log(Level.FINE, "Pedestrian crossing set for the road: {0}", pedestrianCrossing);
     }
 
     /**
@@ -204,7 +204,7 @@ public class Road {
             throw new IllegalStateException("A pedestrian crossing is already associated with this road.");
         }
         this.pedestrianCrossing = pedestrianCrossing;
-        logger.log(Level.INFO, "Pedestrian crossing added to road: {0}", pedestrianCrossing);
+        logger.log(Level.FINE, "Pedestrian crossing added to road: {0}", pedestrianCrossing);
     }
 
     /**
@@ -216,7 +216,7 @@ public class Road {
         if (this.pedestrianCrossing == null) {
             throw new IllegalStateException("No pedestrian crossing is associated with this road.");
         }
-        logger.log(Level.INFO, "Pedestrian crossing removed from road: {0}", this.pedestrianCrossing);
+        logger.log(Level.FINE, "Pedestrian crossing removed from road: {0}", this.pedestrianCrossing);
         this.pedestrianCrossing = null;
     }
 
@@ -253,7 +253,7 @@ public class Road {
         validateInboundLaneMembership(inboundLane);
         validateOutboundLane(outboundLane);
         inboundLane.addAllowedOutgoingLane(outboundLane);
-        logger.log(Level.INFO, "Allowed turn configured from inbound lane {0} to outbound lane {1}",
+        logger.log(Level.FINE, "Allowed turn configured from inbound lane {0} to outbound lane {1}",
                 new Object[] { inboundLane, outboundLane });
     }
 
@@ -276,7 +276,7 @@ public class Road {
             validateOutboundLane(outboundLane);
         }
         inboundLane.setAllowedOutgoingLanes(outboundLanes);
-        logger.log(Level.INFO, "Allowed turns replaced for inbound lane {0}", inboundLane);
+        logger.log(Level.FINE, "Allowed turns replaced for inbound lane {0}", inboundLane);
     }
 
     /**
@@ -367,20 +367,15 @@ public class Road {
      * purposes.
      */
     public void displayLaneInfo() {
-        logger.log(Level.INFO, "Incoming Lanes: {0}", incomingLanes.size());
+        logger.log(Level.FINE, "{0}", this);
         for (Lane lane : incomingLanes) {
-            logger.log(Level.INFO, "Incoming Lane: {0}", lane.getDirection());
+            logger.log(Level.FINE, "Incoming lane: {0}", lane);
         }
-
-        logger.log(Level.INFO, "Outgoing Lanes: {0}", outgoingLanes.size());
         for (Lane lane : outgoingLanes) {
-            logger.log(Level.INFO, "Outgoing Lane: {0}", lane.getDirection());
+            logger.log(Level.FINE, "Outgoing lane: {0}", lane);
         }
-
         if (hasPedestrianCrossing()) {
-            logger.log(Level.INFO, "Pedestrian Crossing is present on this road.");
-        } else {
-            logger.log(Level.INFO, "No Pedestrian Crossing on this road.");
+            logger.log(Level.FINE, "Pedestrian crossing: {0}", pedestrianCrossing);
         }
     }
 
@@ -421,4 +416,43 @@ public class Road {
             throw new IllegalArgumentException("Outbound lane must belong to this road.");
         }
     }
+
+    /**
+     * Returns a compact diagnostic representation of this road.
+     *
+     * @return readable road summary
+     */
+    @Override
+    public String toString() {
+        return "Road{"
+                + "angle=" + angle
+                + ", incomingLaneCount=" + incomingLanes.size()
+                + ", outgoingLaneCount=" + outgoingLanes.size()
+                + ", hasPedestrianCrossing=" + hasPedestrianCrossing()
+                + ", trafficLightCount=" + incomingLanesTrafficLightGroup.getLights().size()
+                + '}';
+    }
+
+    /**
+     * Roads model physical road approaches, so equality is intentionally based
+     * on object identity rather than matching angle or lane counts.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same road
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/main/java/com/trafficlightsimulator/model/TrafficLight.java
+++ b/src/main/java/com/trafficlightsimulator/model/TrafficLight.java
@@ -139,4 +139,43 @@ public class TrafficLight {
     public boolean isMultiColor() {
         return isMultiColor;
     }
+
+    /**
+     * Returns a compact diagnostic representation of this light.
+     *
+     * @return readable traffic-light summary
+     */
+    @Override
+    public String toString() {
+        return "TrafficLight{"
+                + "type=" + type
+                + ", color=" + color
+                + ", state=" + state
+                + ", direction=" + direction
+                + ", multiColor=" + isMultiColor
+                + '}';
+    }
+
+    /**
+     * Traffic lights model physical signal heads, so equality is intentionally
+     * based on object identity rather than matching signal properties.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same light
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/main/java/com/trafficlightsimulator/model/TrafficLightGroup.java
+++ b/src/main/java/com/trafficlightsimulator/model/TrafficLightGroup.java
@@ -49,7 +49,7 @@ public class TrafficLightGroup {
         if (light != null) {
             lights.add(light);
             incompatibleLights.computeIfAbsent(light, ignored -> newIdentitySet());
-            logger.log(Level.INFO, "Traffic light added: {0}", light);
+            logger.log(Level.FINE, "Traffic light added: {0}", light);
         }
     }
 
@@ -65,7 +65,7 @@ public class TrafficLightGroup {
         for (Set<TrafficLight> incompatibleSet : incompatibleLights.values()) {
             incompatibleSet.remove(light);
         }
-        logger.log(Level.INFO, "Traffic light removed: {0}", light);
+        logger.log(Level.FINE, "Traffic light removed: {0}", light);
     }
 
     /**
@@ -86,7 +86,7 @@ public class TrafficLightGroup {
         validateIncompatibilityPair(firstLight, secondLight);
         incompatibleLights.computeIfAbsent(firstLight, ignored -> newIdentitySet()).add(secondLight);
         incompatibleLights.computeIfAbsent(secondLight, ignored -> newIdentitySet()).add(firstLight);
-        logger.log(Level.INFO, "Configured incompatible lights: {0} <-> {1}",
+        logger.log(Level.FINE, "Configured incompatible lights: {0} <-> {1}",
                 new Object[]{firstLight, secondLight});
     }
 
@@ -103,7 +103,7 @@ public class TrafficLightGroup {
         }
         removeIncompatibility(firstLight, secondLight);
         removeIncompatibility(secondLight, firstLight);
-        logger.log(Level.INFO, "Removed incompatible lights: {0} <-> {1}",
+        logger.log(Level.FINE, "Removed incompatible lights: {0} <-> {1}",
                 new Object[]{firstLight, secondLight});
     }
 
@@ -155,7 +155,7 @@ public class TrafficLightGroup {
         validateManagedLight(light);
         ensureCompatibleActivation(light, color, light.getState());
         light.setColor(color);
-        logger.log(Level.INFO, "Set color {0} for light: {1}", new Object[]{color, light});
+        logger.log(Level.FINE, "Set color {0} for light: {1}", new Object[]{color, light});
     }
 
     /**
@@ -176,7 +176,7 @@ public class TrafficLightGroup {
         validateManagedLight(light);
         ensureCompatibleActivation(light, light.getColor(), state);
         light.setState(state);
-        logger.log(Level.INFO, "Set state {0} for light: {1}", new Object[]{state, light});
+        logger.log(Level.FINE, "Set state {0} for light: {1}", new Object[]{state, light});
     }
 
     /**
@@ -227,9 +227,9 @@ public class TrafficLightGroup {
      * diagnostic purposes.
      */
     public void displayGroupStatus() {
+        logger.log(Level.FINE, "{0}", this);
         for (TrafficLight light : lights) {
-            logger.log(Level.INFO, "Light Type: {0}, Color: {1}, State: {2}",
-                       new Object[]{light.getType(), light.getColor(), light.getState()});
+            logger.log(Level.FINE, "Traffic light: {0}", light);
         }
     }
 
@@ -288,4 +288,43 @@ public class TrafficLightGroup {
             incompatibleSet.remove(secondLight);
         }
     }
+
+    /**
+     * Returns a compact diagnostic representation of this group.
+     *
+     * @return readable traffic-light-group summary
+     */
+    @Override
+    public String toString() {
+        int incompatibilityCount = incompatibleLights.values().stream()
+                .mapToInt(Set::size)
+                .sum() / 2;
+        return "TrafficLightGroup{"
+                + "lightCount=" + lights.size()
+                + ", incompatibilityCount=" + incompatibilityCount
+                + '}';
+    }
+
+    /**
+     * Traffic-light groups model physical controller group instances, so
+     * equality is intentionally based on object identity.
+     *
+     * @param obj object to compare
+     * @return {@code true} only when both references point to the same group
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    /**
+     * Returns an identity-based hash code consistent with {@link #equals(Object)}.
+     *
+     * @return identity hash code
+     */
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -116,4 +116,18 @@ class IntersectionTest {
     private TrafficLight trafficLight(Direction direction, Color color, State state) {
         return new TrafficLight(color, state, TrafficLight.Type.TRAFFIC, direction, true);
     }
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        Intersection intersection = new Intersection(2);
+        Intersection sameValueIntersection = new Intersection(2);
+
+        assertEquals(intersection, intersection);
+        assertNotEquals(intersection, sameValueIntersection);
+        assertEquals(System.identityHashCode(intersection), intersection.hashCode());
+        assertTrue(intersection.toString().contains("configuredRoadCapacity=2"));
+        assertTrue(intersection.toString().contains("roadCount=0"));
+        assertFalse(intersection.toString().contains("@"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/LaneTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/LaneTest.java
@@ -156,4 +156,17 @@ class LaneTest {
         assertTrue(exception.getMessage().contains("Illegal turn"));
     }
 
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        Lane lane = new Lane(Lane.Direction.OUTGOING);
+        Lane sameShapeLane = new Lane(Lane.Direction.OUTGOING);
+
+        assertEquals(lane, lane);
+        assertNotEquals(lane, sameShapeLane);
+        assertEquals(System.identityHashCode(lane), lane.hashCode());
+        assertTrue(lane.toString().contains("direction=OUTGOING"));
+        assertFalse(lane.toString().contains("@"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/PedestrianButtonTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/PedestrianButtonTest.java
@@ -40,4 +40,18 @@ class PedestrianButtonTest {
 
         assertFalse(button.isPressed());
     }
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        PedestrianButton button = new PedestrianButton(new TrafficLightGroup());
+        PedestrianButton sameValueButton = new PedestrianButton(new TrafficLightGroup());
+        button.press();
+
+        assertEquals(button, button);
+        assertNotEquals(button, sameValueButton);
+        assertEquals(System.identityHashCode(button), button.hashCode());
+        assertTrue(button.toString().contains("pressed=true"));
+        assertFalse(button.toString().contains("@"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/PedestrianCrossingTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/PedestrianCrossingTest.java
@@ -195,4 +195,17 @@ class PedestrianCrossingTest {
         crossing.deactivate();
         assertFalse(crossing.isActive());
     }
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        PedestrianCrossing crossing = new PedestrianCrossing();
+        PedestrianCrossing sameValueCrossing = new PedestrianCrossing();
+
+        assertEquals(crossing, crossing);
+        assertNotEquals(crossing, sameValueCrossing);
+        assertEquals(System.identityHashCode(crossing), crossing.hashCode());
+        assertTrue(crossing.toString().contains("controlType=AUTOMATED"));
+        assertFalse(crossing.toString().contains("@"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -318,4 +318,18 @@ class RoadTest {
         assertThrows(IndexOutOfBoundsException.class, () -> road.addAllowedTurn(0, 1));
     }
 
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        Road road = new Road(90.0, 1, 2);
+        Road sameValueRoad = new Road(90.0, 1, 2);
+
+        assertEquals(road, road);
+        assertNotEquals(road, sameValueRoad);
+        assertEquals(System.identityHashCode(road), road.hashCode());
+        assertTrue(road.toString().contains("angle=90.0"));
+        assertTrue(road.toString().contains("incomingLaneCount=1"));
+        assertFalse(road.toString().contains("@"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/RoadTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/RoadTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightGroupTest.java
@@ -225,4 +225,19 @@ class TrafficLightGroupTest {
     private TrafficLight pedestrianLight(Color color, State state) {
         return new TrafficLight(color, state, TrafficLight.Type.PEDESTRIAN, Direction.NONE, false);
     }
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        TrafficLightGroup group = new TrafficLightGroup();
+        group.addTrafficLight(trafficLight(Direction.STRAIGHT, Color.RED, State.ON));
+        TrafficLightGroup sameShapeGroup = new TrafficLightGroup();
+        sameShapeGroup.addTrafficLight(trafficLight(Direction.STRAIGHT, Color.RED, State.ON));
+
+        assertEquals(group, group);
+        assertNotEquals(group, sameShapeGroup);
+        assertEquals(System.identityHashCode(group), group.hashCode());
+        assertTrue(group.toString().contains("lightCount=1"));
+        assertFalse(group.toString().contains("@"));
+    }
+
 }

--- a/src/test/java/com/trafficlightsimulator/model/TrafficLightTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/TrafficLightTest.java
@@ -140,4 +140,18 @@ class TrafficLightTest {
     private TrafficLight trafficLight(TrafficLight.Type type, boolean multiColor) {
         return new TrafficLight(Color.RED, State.ON, type, Direction.NONE, multiColor);
     }
+
+    @Test
+    void equality_usesIdentityAndToStringIsReadable() {
+        TrafficLight light = trafficLight(TrafficLight.Type.TRAFFIC, true);
+        TrafficLight sameValueLight = trafficLight(TrafficLight.Type.TRAFFIC, true);
+
+        assertEquals(light, light);
+        assertNotEquals(light, sameValueLight);
+        assertEquals(System.identityHashCode(light), light.hashCode());
+        assertTrue(light.toString().contains("type=TRAFFIC"));
+        assertTrue(light.toString().contains("color=RED"));
+        assertFalse(light.toString().contains("@"));
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Reduce noisy INFO-level logs for routine model operations so normal simulation runs are quieter. 
- Provide readable diagnostic output for core model objects and make equality semantics explicit (identity-based) so relationships target physical instances. 
- Update project documentation and bump the pre-MVP development version to reflect the diagnostics and equality-semantics change.

### Description

- Lowered routine logging from `Level.INFO` to `Level.FINE` across the model and initialization paths and adjusted a few diagnostic `display*` APIs to log readable object summaries. 
- Added `toString()`, identity-based `equals(Object)`, and `hashCode()` implementations to core model entities: `Intersection`, `Road`, `Lane`, `TrafficLight`, `TrafficLightGroup`, `PedestrianCrossing`, and `PedestrianButton`. 
- Updated `TrafficLightSimulationEngine` and several `display*` methods to emit object summaries and preserved warning logs at `Level.WARNING` for skipped/invalid operations. 
- Documentation and metadata updates: bumped `pom.xml` to `0.13.0-SNAPSHOT`, added `Model logging and diagnostics` text to `README.md`, and recorded the change in `CHANGELOG.md`. 
- Added unit tests that assert identity-based equality, `hashCode()` consistency, and readable `toString()` output across the model test suite files.

### Testing

- Source compilation succeeded with `javac -d /tmp/tls-classes $(find src/main/java -name '*.java')` (success). 
- Attempted full test runs with `mvn -B test` and `mvn -B -Djacoco.skip=true test`, but both were blocked by an external Maven Central resolution error (HTTP 403) for `org.jacoco:jacoco-maven-plugin:0.8.12`, preventing execution of the added JUnit tests. 
- Performed local Git checks (`git diff --check`) and committed the changes with the commit message `feat(model): improve diagnostics and identity semantics`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223b4029b88325bf5471335fac6f36)