### PR TITLE
feat(intersection): enforce minimum road angle spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ the current `0.x` baseline.
   including wraparound checks across the `0`/`360` degree boundary.
 - Unit coverage for accepted boundary spacing and rejected too-close road angles.
 - README documentation for intersection road-angle validation.
+- Guarding for `Road.setAngle` after a road is connected to an intersection so
+  later angle mutations cannot break minimum road spacing.
+- Rejection for adding the same `Road` instance to an intersection more than
+  once.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ the current `0.x` baseline.
 
 ### Added
 
+- `Intersection.MIN_ANGLE_BETWEEN_ROADS` and centralized intersection angle
+  spacing validation that rejects roads configured too close to existing roads,
+  including wraparound checks across the `0`/`360` degree boundary.
+- Unit coverage for accepted boundary spacing and rejected too-close road angles.
+- README documentation for intersection road-angle validation.
+
+### Changed
+
+- Bumped the pre-MVP development version from `0.13.0-SNAPSHOT` to
+  `0.14.0-SNAPSHOT` for intersection road-angle validation.
+
+### Added
+
 - Readable `toString()` implementations plus explicit identity-based `equals()`
   and `hashCode()` methods on core model entities (`Intersection`, `Road`,
   `Lane`, `TrafficLight`, `TrafficLightGroup`, `PedestrianCrossing`, and

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ of roads connected to the same intersection. A candidate road must be at least
 `Intersection.MIN_ANGLE_BETWEEN_ROADS` degrees from each existing road, using the
 shortest circular difference so roads near the `0`/`360` degree boundary are
 validated correctly. Roads that violate the spacing rule are rejected with an
-`IllegalArgumentException` and are not added to the intersection.
+`IllegalArgumentException` and are not added to the intersection. After a road
+is connected to an intersection, `Road.setAngle` also checks the same spacing
+rule before changing the angle, so retained `Road` references cannot move
+connected roads into an invalid intersection layout.
 
 ## Lane turn restrictions
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ until a stable `1.0.0` release is declared.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.13.0-SNAPSHOT`
+- **Current development version:** `0.14.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Architecture overview
@@ -99,7 +99,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.13.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.14.0-SNAPSHOT.jar
 ```
 
 ## Generating API documentation
@@ -149,6 +149,14 @@ such as `Intersection.addRoad`, `Road.setNumIncomingLanes`,
 `Road.setNumOutgoingLanes`, `TrafficLightGroup.addTrafficLight`, and
 `Lane.addAllowedOutgoingLane` so validation and safety rules remain enforced.
 
+## Intersection road-angle validation
+
+`Intersection.addRoad` enforces a minimum angular separation between every pair
+of roads connected to the same intersection. A candidate road must be at least
+`Intersection.MIN_ANGLE_BETWEEN_ROADS` degrees from each existing road, using the
+shortest circular difference so roads near the `0`/`360` degree boundary are
+validated correctly. Roads that violate the spacing rule are rejected with an
+`IllegalArgumentException` and are not added to the intersection.
 
 ## Lane turn restrictions
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.13.0-SNAPSHOT</version>
+    <version>0.14.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/config/IntersectionLimits.java
+++ b/src/main/java/com/trafficlightsimulator/config/IntersectionLimits.java
@@ -10,6 +10,12 @@ public final class IntersectionLimits {
     /** Maximum roads that can connect to an intersection. */
     public static final int MAX_ROADS = 8;
 
+    /**
+     * Minimum allowed angular separation, in degrees, between two roads at an
+     * intersection.
+     */
+    public static final double MIN_ANGLE_BETWEEN_ROADS = 30.0;
+
     private IntersectionLimits() {
         // Utility class: prevent instantiation.
     }

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -78,8 +78,10 @@ public class Intersection {
      * Adds a road to this intersection.
      *
      * @param road road to add; must not be null
-     * @throws IllegalArgumentException if {@code road} is null or is closer
-     *                                  than {@link #MIN_ANGLE_BETWEEN_ROADS}
+     * @throws IllegalArgumentException if {@code road} is null, is already
+     *                                  connected to an intersection, or is
+     *                                  closer than
+     *                                  {@link #MIN_ANGLE_BETWEEN_ROADS}
      *                                  degrees to an existing road
      * @throws IllegalStateException    if the intersection already contains the
      *                                  declared number of roads
@@ -91,7 +93,14 @@ public class Intersection {
         if (roads.size() >= numberOfRoads) {
             throw new IllegalStateException("Cannot add more roads than the specified number: " + numberOfRoads);
         }
+        if (roads.contains(road)) {
+            throw new IllegalArgumentException("Road is already connected to this intersection.");
+        }
+        if (road.isConnectedToDifferentIntersection(this)) {
+            throw new IllegalArgumentException("Road is already connected to another intersection.");
+        }
         validateMinimumAngleBetweenRoads(road);
+        road.attachToIntersection(this);
         roads.add(road);
         logger.log(Level.FINE, "Added road to intersection. Total roads now: {0}", roads.size());
     }
@@ -251,13 +260,28 @@ public class Intersection {
         }
     }
 
+    void validateRoadAngleChange(Road road, double candidateAngle) {
+        if (!roads.contains(road)) {
+            throw new IllegalArgumentException(
+                    "Road must belong to this intersection before its angle can be validated.");
+        }
+        validateMinimumAngleBetweenRoads(road, candidateAngle);
+    }
+
     private void validateMinimumAngleBetweenRoads(Road candidateRoad) {
+        validateMinimumAngleBetweenRoads(candidateRoad, candidateRoad.getAngle());
+    }
+
+    private void validateMinimumAngleBetweenRoads(Road candidateRoad, double candidateAngle) {
         for (Road existingRoad : roads) {
-            double angleDifference = calculateShortestAngleDifference(candidateRoad.getAngle(),
+            if (existingRoad == candidateRoad) {
+                continue;
+            }
+            double angleDifference = calculateShortestAngleDifference(candidateAngle,
                     existingRoad.getAngle());
             if (angleDifference < MIN_ANGLE_BETWEEN_ROADS) {
                 throw new IllegalArgumentException("Road angle must be at least " + MIN_ANGLE_BETWEEN_ROADS
-                        + " degrees from every existing road. Candidate angle " + candidateRoad.getAngle()
+                        + " degrees from every existing road. Candidate angle " + candidateAngle
                         + " is " + angleDifference + " degrees from existing road angle "
                         + existingRoad.getAngle() + ".");
             }

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -12,9 +12,11 @@ import java.util.logging.Logger;
  * A road intersection that connects two to eight {@link Road} instances.
  *
  * <p>The intersection enforces a declared capacity: callers first set the
- * expected road count and then add roads one by one. Once the intersection
- * reaches capacity, {@link #isIntersectionSetupComplete()} returns
- * {@code true} and no additional roads can be added.
+ * expected road count and then add roads one by one. Each added road must be
+ * at least {@link #MIN_ANGLE_BETWEEN_ROADS} degrees away from every existing
+ * road, measured by the shortest circular angle between their headings. Once
+ * the intersection reaches capacity, {@link #isIntersectionSetupComplete()}
+ * returns {@code true} and no additional roads can be added.
  *
  * <p>Safety invariants for incompatible traffic lights are registered at the
  * intersection level through
@@ -24,6 +26,12 @@ import java.util.logging.Logger;
  */
 public class Intersection {
     private static final Logger logger = Logger.getLogger(Intersection.class.getName());
+
+    /**
+     * Minimum allowed angular separation, in degrees, between any two roads
+     * connected to this intersection.
+     */
+    public static final double MIN_ANGLE_BETWEEN_ROADS = IntersectionLimits.MIN_ANGLE_BETWEEN_ROADS;
 
     private int numberOfRoads;
     private final List<Road> roads;
@@ -70,7 +78,9 @@ public class Intersection {
      * Adds a road to this intersection.
      *
      * @param road road to add; must not be null
-     * @throws IllegalArgumentException if {@code road} is null
+     * @throws IllegalArgumentException if {@code road} is null or is closer
+     *                                  than {@link #MIN_ANGLE_BETWEEN_ROADS}
+     *                                  degrees to an existing road
      * @throws IllegalStateException    if the intersection already contains the
      *                                  declared number of roads
      */
@@ -81,6 +91,7 @@ public class Intersection {
         if (roads.size() >= numberOfRoads) {
             throw new IllegalStateException("Cannot add more roads than the specified number: " + numberOfRoads);
         }
+        validateMinimumAngleBetweenRoads(road);
         roads.add(road);
         logger.log(Level.FINE, "Added road to intersection. Total roads now: {0}", roads.size());
     }
@@ -238,6 +249,24 @@ public class Intersection {
                 road.getPedestrianCrossing().displayCrossingStatus();
             }
         }
+    }
+
+    private void validateMinimumAngleBetweenRoads(Road candidateRoad) {
+        for (Road existingRoad : roads) {
+            double angleDifference = calculateShortestAngleDifference(candidateRoad.getAngle(),
+                    existingRoad.getAngle());
+            if (angleDifference < MIN_ANGLE_BETWEEN_ROADS) {
+                throw new IllegalArgumentException("Road angle must be at least " + MIN_ANGLE_BETWEEN_ROADS
+                        + " degrees from every existing road. Candidate angle " + candidateRoad.getAngle()
+                        + " is " + angleDifference + " degrees from existing road angle "
+                        + existingRoad.getAngle() + ".");
+            }
+        }
+    }
+
+    private double calculateShortestAngleDifference(double firstAngle, double secondAngle) {
+        double absoluteDifference = Math.abs(firstAngle - secondAngle);
+        return Math.min(absoluteDifference, 360.0 - absoluteDifference);
     }
 
     private TrafficLightGroup findTrafficLightGroup(TrafficLight light) {

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -34,6 +34,7 @@ public class Road {
     private final List<Lane> outgoingLanes;
     private PedestrianCrossing pedestrianCrossing;
     private TrafficLightGroup incomingLanesTrafficLightGroup;
+    private Intersection intersection;
     private double angle;
     private int numIncomingLanes;
     private int numOutgoingLanes;
@@ -56,6 +57,7 @@ public class Road {
         this.outgoingLanes = new ArrayList<>();
         this.pedestrianCrossing = null;
         this.incomingLanesTrafficLightGroup = new TrafficLightGroup();
+        this.intersection = null;
         setAngle(angle);
         setNumIncomingLanes(numIncomingLanes);
         setNumOutgoingLanes(numOutgoingLanes);
@@ -67,11 +69,14 @@ public class Road {
      * @param angle angle in degrees; must be in
      *              [{@link RoadLimits#MIN_ANGLE_DEGREES},
      *              {@link RoadLimits#MAX_ANGLE_DEGREES_EXCLUSIVE})
-     * @throws IllegalArgumentException if the angle is out of range
+     * @throws IllegalArgumentException if the angle is out of range or would
+     *                                  violate the minimum road-angle spacing
+     *                                  required by the owning intersection
      */
     public void setAngle(double angle) {
-        if (angle < RoadLimits.MIN_ANGLE_DEGREES || angle >= RoadLimits.MAX_ANGLE_DEGREES_EXCLUSIVE) {
-            throw new IllegalArgumentException("Angle must be between 0 and 360 degrees.");
+        validateAngleRange(angle);
+        if (intersection != null) {
+            intersection.validateRoadAngleChange(this, angle);
         }
         this.angle = angle;
         logger.log(Level.FINE, "Angle for road set to: {0} degrees", angle);
@@ -376,6 +381,23 @@ public class Road {
         }
         if (hasPedestrianCrossing()) {
             logger.log(Level.FINE, "Pedestrian crossing: {0}", pedestrianCrossing);
+        }
+    }
+
+    boolean isConnectedToDifferentIntersection(Intersection intersection) {
+        return this.intersection != null && this.intersection != intersection;
+    }
+
+    void attachToIntersection(Intersection intersection) {
+        if (isConnectedToDifferentIntersection(intersection)) {
+            throw new IllegalStateException("Road already belongs to another intersection.");
+        }
+        this.intersection = intersection;
+    }
+
+    private void validateAngleRange(double angle) {
+        if (angle < RoadLimits.MIN_ANGLE_DEGREES || angle >= RoadLimits.MAX_ANGLE_DEGREES_EXCLUSIVE) {
+            throw new IllegalArgumentException("Angle must be between 0 and 360 degrees.");
         }
     }
 

--- a/src/test/java/com/trafficlightsimulator/engine/TrafficLightSimulationEngineTest.java
+++ b/src/test/java/com/trafficlightsimulator/engine/TrafficLightSimulationEngineTest.java
@@ -22,8 +22,8 @@ class TrafficLightSimulationEngineTest {
     @Test
     void initializesRoadTrafficLightGroupsToOff() {
         Intersection intersection = new Intersection(2);
-        Road firstRoad = roadWithTrafficLight(State.ON);
-        Road secondRoad = roadWithTrafficLight(State.BLINKING);
+        Road firstRoad = roadWithTrafficLight(0.0, State.ON);
+        Road secondRoad = roadWithTrafficLight(90.0, State.BLINKING);
         intersection.addRoad(firstRoad);
         intersection.addRoad(secondRoad);
 
@@ -55,8 +55,8 @@ class TrafficLightSimulationEngineTest {
         assertEquals(State.OFF, pedestrianLight.getState());
     }
 
-    private Road roadWithTrafficLight(State initialState) {
-        Road road = new Road(0.0, 1, 1);
+    private Road roadWithTrafficLight(double angle, State initialState) {
+        Road road = new Road(angle, 1, 1);
         road.addTrafficLightToIncomingGroup(new TrafficLight(
                 Color.GREEN,
                 initialState,

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -54,6 +54,19 @@ class IntersectionTest {
     }
 
     @Test
+    void addRoad_rejectsRoadAlreadyConnectedToIntersection() {
+        Intersection intersection = new Intersection(3);
+        Road road = new Road(0.0, 1, 1);
+        intersection.addRoad(road);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> intersection.addRoad(road));
+
+        assertTrue(exception.getMessage().contains("already connected"));
+        assertEquals(1, intersection.getRoads().size());
+    }
+
+    @Test
     void addRoad_acceptsRoadAtMinimumAngleFromExistingRoad() {
         Intersection intersection = new Intersection(2);
         intersection.addRoad(new Road(0.0, 1, 1));
@@ -102,6 +115,35 @@ class IntersectionTest {
         assertDoesNotThrow(() -> intersection.addRoad(roadAtMinimumAngle));
 
         assertEquals(2, intersection.getRoads().size());
+    }
+
+    @Test
+    void roadSetAngleRejectsMutationThatWouldBreakIntersectionSpacing() {
+        Intersection intersection = new Intersection(2);
+        Road firstRoad = new Road(0.0, 1, 1);
+        Road secondRoad = new Road(90.0, 1, 1);
+        intersection.addRoad(firstRoad);
+        intersection.addRoad(secondRoad);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> secondRoad.setAngle(5.0));
+
+        assertTrue(exception.getMessage().contains("at least " + Intersection.MIN_ANGLE_BETWEEN_ROADS));
+        assertEquals(90.0, secondRoad.getAngle());
+        assertTrue(intersection.isIntersectionSetupComplete());
+    }
+
+    @Test
+    void roadSetAngleAcceptsMutationThatPreservesIntersectionSpacing() {
+        Intersection intersection = new Intersection(2);
+        Road firstRoad = new Road(0.0, 1, 1);
+        Road secondRoad = new Road(90.0, 1, 1);
+        intersection.addRoad(firstRoad);
+        intersection.addRoad(secondRoad);
+
+        assertDoesNotThrow(() -> secondRoad.setAngle(180.0));
+
+        assertEquals(180.0, secondRoad.getAngle());
     }
 
     @Test

--- a/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
+++ b/src/test/java/com/trafficlightsimulator/model/IntersectionTest.java
@@ -54,6 +54,57 @@ class IntersectionTest {
     }
 
     @Test
+    void addRoad_acceptsRoadAtMinimumAngleFromExistingRoad() {
+        Intersection intersection = new Intersection(2);
+        intersection.addRoad(new Road(0.0, 1, 1));
+        Road roadAtMinimumAngle = new Road(Intersection.MIN_ANGLE_BETWEEN_ROADS, 1, 1);
+
+        assertDoesNotThrow(() -> intersection.addRoad(roadAtMinimumAngle));
+
+        assertEquals(2, intersection.getRoads().size());
+        assertSame(roadAtMinimumAngle, intersection.getRoads().get(1));
+    }
+
+    @Test
+    void addRoad_rejectsRoadBelowMinimumAngleFromExistingRoad() {
+        Intersection intersection = new Intersection(2);
+        Road existingRoad = new Road(90.0, 1, 1);
+        intersection.addRoad(existingRoad);
+        Road tooCloseRoad = new Road(90.0 + Intersection.MIN_ANGLE_BETWEEN_ROADS - 0.5, 1, 1);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> intersection.addRoad(tooCloseRoad));
+
+        assertTrue(exception.getMessage().contains("at least " + Intersection.MIN_ANGLE_BETWEEN_ROADS));
+        assertEquals(1, intersection.getRoads().size());
+        assertSame(existingRoad, intersection.getRoads().get(0));
+    }
+
+    @Test
+    void addRoad_rejectsRoadBelowMinimumAngleAcrossZeroDegreeBoundary() {
+        Intersection intersection = new Intersection(2);
+        intersection.addRoad(new Road(350.0, 1, 1));
+        Road tooCloseRoad = new Road(5.0, 1, 1);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> intersection.addRoad(tooCloseRoad));
+
+        assertTrue(exception.getMessage().contains("350.0"));
+        assertEquals(1, intersection.getRoads().size());
+    }
+
+    @Test
+    void addRoad_acceptsRoadAtMinimumAngleAcrossZeroDegreeBoundary() {
+        Intersection intersection = new Intersection(2);
+        intersection.addRoad(new Road(345.0, 1, 1));
+        Road roadAtMinimumAngle = new Road(15.0, 1, 1);
+
+        assertDoesNotThrow(() -> intersection.addRoad(roadAtMinimumAngle));
+
+        assertEquals(2, intersection.getRoads().size());
+    }
+
+    @Test
     void getRoads_returnsUnmodifiableViewBackedByInternalRoads() {
         Intersection intersection = new Intersection(2);
         Road road = new Road(0.0, 1, 1);


### PR DESCRIPTION
### Motivation
- Prevent adding roads that are too close in heading at the same intersection to avoid physically implausible configurations and reduce potential signal conflicts.

### Description
- Add `IntersectionLimits.MIN_ANGLE_BETWEEN_ROADS` and expose it as `Intersection.MIN_ANGLE_BETWEEN_ROADS`.
- Validate candidate road angles in `Intersection.addRoad` using a shortest circular-angle difference and reject candidates closer than the configured minimum.
- Implement `validateMinimumAngleBetweenRoads(Road)` and `calculateShortestAngleDifference(double,double)` helpers, add unit tests covering boundary and wraparound (`0`/`360`) cases, and document the behavior in `README.md` and `CHANGELOG.md`.
- Bump the development version in `pom.xml` and README from `0.13.0-SNAPSHOT` to `0.14.0-SNAPSHOT`.

### Testing
- `mvn -B test` was attempted but failed due to a Maven Central `403 Forbidden` while resolving `org.jacoco:jacoco-maven-plugin:0.8.12` (environmental/network issue), so full test lifecycle could not complete.
- Project sources were compiled with `javac -d /tmp/tls-classes $(find src/main/java -name '*.java' -print)` and a small runtime check program exercising accepted and rejected `addRoad` scenarios was compiled and executed successfully.
- Local static checks (`git diff --check`) ran without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2243a7fa788325b7cc66509add9cef)