### PR TITLE
feat(config): add builders and centralized validation constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ the current `0.x` baseline.
 
 ### Added
 
+- `ValidationConstants` as the single source for road-angle, lane-count,
+  intersection road-count, and minimum road-angle-spacing limits.
+- Fluent `RoadBuilder` and `IntersectionBuilder` factories that enforce shared
+  construction validation and cover optional road crossings/lights plus
+  intersection road attachment.
+- Builder unit tests covering valid construction and invalid validation paths.
+- README documentation for the fluent builders and centralized validation
+  constants.
+
+### Changed
+
+- Bumped the pre-MVP development version from `0.14.0-SNAPSHOT` to
+  `0.15.0-SNAPSHOT` for builder/factory construction support.
+- Updated model validation paths to use `ValidationConstants`, while retaining
+  `RoadLimits` and `IntersectionLimits` as compatibility facades.
+
+### Added
+
 - `Intersection.MIN_ANGLE_BETWEEN_ROADS` and centralized intersection angle
   spacing validation that rejects roads configured too close to existing roads,
   including wraparound checks across the `0`/`360` degree boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ the current `0.x` baseline.
 - Updated model validation paths to use `ValidationConstants`, while retaining
   `RoadLimits` and `IntersectionLimits` as compatibility facades.
 
+### Fixed
+
+- `IntersectionBuilder.build()` now prevalidates configured roads before attaching
+  any of them, so failed builds do not leave earlier roads owned by a discarded
+  intersection.
+
 ### Added
 
 - `Intersection.MIN_ANGLE_BETWEEN_ROADS` and centralized intersection angle

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ until a stable `1.0.0` release is declared.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.14.0-SNAPSHOT`
+- **Current development version:** `0.15.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Architecture overview
@@ -30,8 +30,8 @@ com.trafficlightsimulator
 │              TrafficLightGroup, PedestrianCrossing, PedestrianButton,
 │              Color, Direction, State
 ├── engine   – Simulation lifecycle coordination (TrafficLightSimulationEngine)
-└── config   – Validation constants (IntersectionLimits, RoadLimits);
-               future home of builders and factories
+└── config   – Validation constants, compatibility limit facades,
+               and fluent Road/Intersection builders
 ```
 
 **Key design decisions:**
@@ -99,7 +99,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.14.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.15.0-SNAPSHOT.jar
 ```
 
 ## Generating API documentation
@@ -139,6 +139,29 @@ To resolve it:
    mvn -U -B verify
    ```
 
+
+## Fluent builders and validation constants
+
+Use `RoadBuilder` and `IntersectionBuilder` from the `config` package when you
+want construction-time validation with a fluent API. Builders use the shared
+`ValidationConstants` values for road angles, lane counts, road-count bounds, and
+minimum road-angle spacing, so new construction paths and model mutators enforce
+the same limits. The older `RoadLimits` and `IntersectionLimits` classes remain
+as compatibility facades that delegate to `ValidationConstants`.
+
+Example:
+
+```java
+Road north = RoadBuilder.atAngle(0.0)
+        .lanes(2, 2)
+        .build();
+Road east = RoadBuilder.atAngle(90.0).build();
+
+Intersection intersection = IntersectionBuilder.withRoadCapacity(2)
+        .addRoad(north)
+        .addRoad(east)
+        .build();
+```
 
 ## Model collection encapsulation
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ Use `RoadBuilder` and `IntersectionBuilder` from the `config` package when you
 want construction-time validation with a fluent API. Builders use the shared
 `ValidationConstants` values for road angles, lane counts, road-count bounds, and
 minimum road-angle spacing, so new construction paths and model mutators enforce
-the same limits. The older `RoadLimits` and `IntersectionLimits` classes remain
-as compatibility facades that delegate to `ValidationConstants`.
+the same limits. `IntersectionBuilder.build()` validates configured roads before
+attaching any of them, which keeps failed builds from partially owning roads. The
+older `RoadLimits` and `IntersectionLimits` classes remain as compatibility
+facades that delegate to `ValidationConstants`.
 
 Example:
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.15.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/src/main/java/com/trafficlightsimulator/config/IntersectionBuilder.java
+++ b/src/main/java/com/trafficlightsimulator/config/IntersectionBuilder.java
@@ -11,8 +11,8 @@ import java.util.List;
  * Fluent factory for validated {@link Intersection} instances.
  *
  * <p>Road-count bounds are checked when the capacity is configured, and road
- * capacity plus angle-spacing rules are enforced when {@link #build()} adds the
- * collected roads to the intersection.
+ * capacity plus angle-spacing rules are validated before {@link #build()} adds
+ * any collected road to the intersection.
  */
 public final class IntersectionBuilder {
     private Integer roadCapacity;
@@ -108,13 +108,15 @@ public final class IntersectionBuilder {
      * fully assembled intersection.
      *
      * @return configured intersection
-     * @throws IllegalArgumentException if inferred capacity is out of range or a
-     *                                  road violates intersection validation
+     * @throws IllegalArgumentException if inferred capacity is out of range, a
+     *                                  road is already attached to an intersection,
+     *                                  or configured roads violate angle spacing
      * @throws IllegalStateException    if adding roads exceeds capacity
      */
     public Intersection build() {
         int capacity = roadCapacity != null ? roadCapacity : inferRoadCapacity();
         validateRoadCapacity(capacity);
+        validateRoadsBeforeAttachment();
         Intersection intersection = new Intersection(capacity);
         for (Road road : roads) {
             intersection.addRoad(road);
@@ -134,5 +136,38 @@ public final class IntersectionBuilder {
             throw new IllegalArgumentException("Number of roads must be between "
                     + ValidationConstants.MIN_ROADS + " and " + ValidationConstants.MAX_ROADS);
         }
+    }
+
+    private void validateRoadsBeforeAttachment() {
+        for (Road road : roads) {
+            if (road.isConnectedToIntersection()) {
+                throw new IllegalArgumentException("Road is already connected to an intersection.");
+            }
+        }
+        validateMinimumAngleBetweenConfiguredRoads();
+    }
+
+    private void validateMinimumAngleBetweenConfiguredRoads() {
+        for (int candidateIndex = 0; candidateIndex < roads.size(); candidateIndex++) {
+            Road candidateRoad = roads.get(candidateIndex);
+            for (int existingIndex = 0; existingIndex < candidateIndex; existingIndex++) {
+                Road existingRoad = roads.get(existingIndex);
+                double angleDifference = calculateShortestAngleDifference(candidateRoad.getAngle(),
+                        existingRoad.getAngle());
+                if (angleDifference < ValidationConstants.MIN_ANGLE_BETWEEN_ROADS) {
+                    throw new IllegalArgumentException("Road angle must be at least "
+                            + ValidationConstants.MIN_ANGLE_BETWEEN_ROADS
+                            + " degrees from every existing road. Candidate angle "
+                            + candidateRoad.getAngle() + " is " + angleDifference
+                            + " degrees from existing road angle " + existingRoad.getAngle() + ".");
+                }
+            }
+        }
+    }
+
+    private double calculateShortestAngleDifference(double firstAngle, double secondAngle) {
+        double absoluteDifference = Math.abs(firstAngle - secondAngle);
+        return Math.min(absoluteDifference,
+                ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE - absoluteDifference);
     }
 }

--- a/src/main/java/com/trafficlightsimulator/config/IntersectionBuilder.java
+++ b/src/main/java/com/trafficlightsimulator/config/IntersectionBuilder.java
@@ -1,0 +1,138 @@
+package com.trafficlightsimulator.config;
+
+import com.trafficlightsimulator.model.Intersection;
+import com.trafficlightsimulator.model.Road;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Fluent factory for validated {@link Intersection} instances.
+ *
+ * <p>Road-count bounds are checked when the capacity is configured, and road
+ * capacity plus angle-spacing rules are enforced when {@link #build()} adds the
+ * collected roads to the intersection.
+ */
+public final class IntersectionBuilder {
+    private Integer roadCapacity;
+    private final List<Road> roads = new ArrayList<>();
+
+    private IntersectionBuilder() {
+        // Use factory methods.
+    }
+
+    /**
+     * Starts an intersection builder with no roads configured yet.
+     *
+     * @return new intersection builder
+     */
+    public static IntersectionBuilder intersection() {
+        return new IntersectionBuilder();
+    }
+
+    /**
+     * Starts an intersection builder with the declared road capacity.
+     *
+     * @param roadCapacity expected number of roads
+     * @return new intersection builder
+     */
+    public static IntersectionBuilder withRoadCapacity(int roadCapacity) {
+        return intersection().roadCapacity(roadCapacity);
+    }
+
+    /**
+     * Sets the declared road capacity.
+     *
+     * @param roadCapacity expected number of roads; must be within shared bounds
+     * @return this builder
+     * @throws IllegalArgumentException if the capacity is out of range or lower
+     *                                  than roads already added to this builder
+     */
+    public IntersectionBuilder roadCapacity(int roadCapacity) {
+        validateRoadCapacity(roadCapacity);
+        if (roadCapacity < roads.size()) {
+            throw new IllegalArgumentException(
+                    "Road capacity cannot be less than the number of roads already added: " + roads.size());
+        }
+        this.roadCapacity = roadCapacity;
+        return this;
+    }
+
+    /**
+     * Adds a road that should belong to the built intersection.
+     *
+     * @param road road to add; must not be null
+     * @return this builder
+     * @throws IllegalArgumentException if the road is null or already added to
+     *                                  this builder
+     * @throws IllegalStateException    if the configured capacity is already full
+     */
+    public IntersectionBuilder addRoad(Road road) {
+        if (road == null) {
+            throw new IllegalArgumentException("Road cannot be null.");
+        }
+        if (roads.contains(road)) {
+            throw new IllegalArgumentException("Road is already added to this builder.");
+        }
+        if (roadCapacity != null && roads.size() >= roadCapacity) {
+            throw new IllegalStateException("Cannot add more roads than the specified number: " + roadCapacity);
+        }
+        roads.add(road);
+        return this;
+    }
+
+    /**
+     * Adds all roads from the supplied collection in iteration order.
+     *
+     * @param roads roads to add; must not be null and must not contain nulls
+     * @return this builder
+     */
+    public IntersectionBuilder roads(Collection<Road> roads) {
+        if (roads == null) {
+            throw new IllegalArgumentException("Road collection cannot be null.");
+        }
+        for (Road road : roads) {
+            addRoad(road);
+        }
+        return this;
+    }
+
+    /**
+     * Builds an intersection and attaches the configured roads.
+     *
+     * <p>If no capacity was configured, the builder infers capacity from the
+     * supplied road count, while still respecting the minimum road count. This
+     * supports both {@code withRoadCapacity(4).build()} for an empty intersection
+     * shell and {@code intersection().addRoad(...).addRoad(...).build()} for a
+     * fully assembled intersection.
+     *
+     * @return configured intersection
+     * @throws IllegalArgumentException if inferred capacity is out of range or a
+     *                                  road violates intersection validation
+     * @throws IllegalStateException    if adding roads exceeds capacity
+     */
+    public Intersection build() {
+        int capacity = roadCapacity != null ? roadCapacity : inferRoadCapacity();
+        validateRoadCapacity(capacity);
+        Intersection intersection = new Intersection(capacity);
+        for (Road road : roads) {
+            intersection.addRoad(road);
+        }
+        return intersection;
+    }
+
+    private int inferRoadCapacity() {
+        if (roads.isEmpty()) {
+            return ValidationConstants.MIN_ROADS;
+        }
+        return roads.size();
+    }
+
+    private void validateRoadCapacity(int roadCapacity) {
+        if (roadCapacity < ValidationConstants.MIN_ROADS || roadCapacity > ValidationConstants.MAX_ROADS) {
+            throw new IllegalArgumentException("Number of roads must be between "
+                    + ValidationConstants.MIN_ROADS + " and " + ValidationConstants.MAX_ROADS);
+        }
+    }
+}

--- a/src/main/java/com/trafficlightsimulator/config/IntersectionLimits.java
+++ b/src/main/java/com/trafficlightsimulator/config/IntersectionLimits.java
@@ -2,19 +2,24 @@ package com.trafficlightsimulator.config;
 
 /**
  * Validation limits for intersection topology configuration.
+ *
+ * @deprecated use {@link ValidationConstants}; retained as a compatibility
+ *             facade for callers that referenced the former intersection-specific
+ *             constants holder.
  */
+@Deprecated(since = "0.15.0", forRemoval = false)
 public final class IntersectionLimits {
     /** Minimum roads required for an intersection. */
-    public static final int MIN_ROADS = 2;
+    public static final int MIN_ROADS = ValidationConstants.MIN_ROADS;
 
     /** Maximum roads that can connect to an intersection. */
-    public static final int MAX_ROADS = 8;
+    public static final int MAX_ROADS = ValidationConstants.MAX_ROADS;
 
     /**
      * Minimum allowed angular separation, in degrees, between two roads at an
      * intersection.
      */
-    public static final double MIN_ANGLE_BETWEEN_ROADS = 30.0;
+    public static final double MIN_ANGLE_BETWEEN_ROADS = ValidationConstants.MIN_ANGLE_BETWEEN_ROADS;
 
     private IntersectionLimits() {
         // Utility class: prevent instantiation.

--- a/src/main/java/com/trafficlightsimulator/config/RoadBuilder.java
+++ b/src/main/java/com/trafficlightsimulator/config/RoadBuilder.java
@@ -1,0 +1,160 @@
+package com.trafficlightsimulator.config;
+
+import com.trafficlightsimulator.model.PedestrianCrossing;
+import com.trafficlightsimulator.model.Road;
+import com.trafficlightsimulator.model.TrafficLight;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fluent factory for validated {@link Road} instances.
+ *
+ * <p>The builder mirrors {@link Road}'s construction-time validation while
+ * keeping road assembly readable when optional crossings or traffic lights are
+ * configured alongside geometry and lane counts.
+ */
+public final class RoadBuilder {
+    private double angle = ValidationConstants.MIN_ANGLE_DEGREES;
+    private int incomingLaneCount = ValidationConstants.MIN_LANES;
+    private int outgoingLaneCount = ValidationConstants.MIN_LANES;
+    private PedestrianCrossing pedestrianCrossing;
+    private final List<TrafficLight> incomingTrafficLights = new ArrayList<>();
+
+    private RoadBuilder() {
+        // Use factory methods.
+    }
+
+    /**
+     * Starts a road builder using valid defaults: angle {@code 0.0}, one
+     * incoming lane, and one outgoing lane.
+     *
+     * @return new road builder
+     */
+    public static RoadBuilder road() {
+        return new RoadBuilder();
+    }
+
+    /**
+     * Starts a road builder with the required geometry supplied up front.
+     *
+     * @param angle road angle in degrees
+     * @return new road builder
+     */
+    public static RoadBuilder atAngle(double angle) {
+        return road().angle(angle);
+    }
+
+    /**
+     * Sets the road angle in degrees.
+     *
+     * @param angle angle in [{@link ValidationConstants#MIN_ANGLE_DEGREES},
+     *              {@link ValidationConstants#MAX_ANGLE_DEGREES_EXCLUSIVE})
+     * @return this builder
+     * @throws IllegalArgumentException if the angle is out of range
+     */
+    public RoadBuilder angle(double angle) {
+        validateAngle(angle);
+        this.angle = angle;
+        return this;
+    }
+
+    /**
+     * Sets the number of incoming lanes.
+     *
+     * @param incomingLaneCount incoming lane count
+     * @return this builder
+     * @throws IllegalArgumentException if the count is below the minimum
+     */
+    public RoadBuilder incomingLanes(int incomingLaneCount) {
+        validateLaneCount(incomingLaneCount, "incoming");
+        this.incomingLaneCount = incomingLaneCount;
+        return this;
+    }
+
+    /**
+     * Sets the number of outgoing lanes.
+     *
+     * @param outgoingLaneCount outgoing lane count
+     * @return this builder
+     * @throws IllegalArgumentException if the count is below the minimum
+     */
+    public RoadBuilder outgoingLanes(int outgoingLaneCount) {
+        validateLaneCount(outgoingLaneCount, "outgoing");
+        this.outgoingLaneCount = outgoingLaneCount;
+        return this;
+    }
+
+    /**
+     * Sets incoming and outgoing lane counts together.
+     *
+     * @param incomingLaneCount incoming lane count
+     * @param outgoingLaneCount outgoing lane count
+     * @return this builder
+     */
+    public RoadBuilder lanes(int incomingLaneCount, int outgoingLaneCount) {
+        return incomingLanes(incomingLaneCount).outgoingLanes(outgoingLaneCount);
+    }
+
+    /**
+     * Associates a pedestrian crossing with the road being built.
+     *
+     * @param pedestrianCrossing crossing to attach; must not be null
+     * @return this builder
+     * @throws IllegalArgumentException if the crossing is null
+     */
+    public RoadBuilder pedestrianCrossing(PedestrianCrossing pedestrianCrossing) {
+        if (pedestrianCrossing == null) {
+            throw new IllegalArgumentException("Pedestrian crossing cannot be null.");
+        }
+        this.pedestrianCrossing = pedestrianCrossing;
+        return this;
+    }
+
+    /**
+     * Adds a traffic light to the road's incoming-lane light group.
+     *
+     * @param trafficLight traffic light to add; must not be null
+     * @return this builder
+     * @throws IllegalArgumentException if the light is null
+     */
+    public RoadBuilder addIncomingTrafficLight(TrafficLight trafficLight) {
+        if (trafficLight == null) {
+            throw new IllegalArgumentException("Traffic light cannot be null.");
+        }
+        incomingTrafficLights.add(trafficLight);
+        return this;
+    }
+
+    /**
+     * Builds a validated road and applies optional crossing/light configuration.
+     *
+     * @return configured road
+     */
+    public Road build() {
+        Road road = new Road(angle, incomingLaneCount, outgoingLaneCount);
+        if (pedestrianCrossing != null) {
+            road.addPedestrianCrossing(pedestrianCrossing);
+        }
+        for (TrafficLight trafficLight : incomingTrafficLights) {
+            road.addTrafficLightToIncomingGroup(trafficLight);
+        }
+        return road;
+    }
+
+    private void validateAngle(double angle) {
+        if (angle < ValidationConstants.MIN_ANGLE_DEGREES
+                || angle >= ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE) {
+            throw new IllegalArgumentException("Angle must be between "
+                    + ValidationConstants.MIN_ANGLE_DEGREES + " and "
+                    + ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE + " degrees.");
+        }
+    }
+
+    private void validateLaneCount(int laneCount, String laneType) {
+        if (laneCount < ValidationConstants.MIN_LANES) {
+            throw new IllegalArgumentException("Number of " + laneType + " lanes must be at least "
+                    + ValidationConstants.MIN_LANES + ".");
+        }
+    }
+}

--- a/src/main/java/com/trafficlightsimulator/config/RoadLimits.java
+++ b/src/main/java/com/trafficlightsimulator/config/RoadLimits.java
@@ -2,16 +2,21 @@ package com.trafficlightsimulator.config;
 
 /**
  * Validation limits for road geometry and lane configuration.
+ *
+ * @deprecated use {@link ValidationConstants}; retained as a compatibility
+ *             facade for callers that referenced the former road-specific
+ *             constants holder.
  */
+@Deprecated(since = "0.15.0", forRemoval = false)
 public final class RoadLimits {
     /** Inclusive lower bound for a road angle in degrees. */
-    public static final double MIN_ANGLE_DEGREES = 0.0;
+    public static final double MIN_ANGLE_DEGREES = ValidationConstants.MIN_ANGLE_DEGREES;
 
     /** Exclusive upper bound for a road angle in degrees. */
-    public static final double MAX_ANGLE_DEGREES_EXCLUSIVE = 360.0;
+    public static final double MAX_ANGLE_DEGREES_EXCLUSIVE = ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE;
 
     /** Minimum number of incoming or outgoing lanes on a road. */
-    public static final int MIN_LANES = 1;
+    public static final int MIN_LANES = ValidationConstants.MIN_LANES;
 
     private RoadLimits() {
         // Utility class: prevent instantiation.

--- a/src/main/java/com/trafficlightsimulator/config/ValidationConstants.java
+++ b/src/main/java/com/trafficlightsimulator/config/ValidationConstants.java
@@ -1,0 +1,36 @@
+package com.trafficlightsimulator.config;
+
+/**
+ * Shared validation constants for road geometry, lane counts, and intersection
+ * topology.
+ *
+ * <p>Model classes, builders, and compatibility limit holders should reference
+ * this single source so range changes stay consistent across construction and
+ * mutation paths.
+ */
+public final class ValidationConstants {
+    /** Inclusive lower bound for a road angle in degrees. */
+    public static final double MIN_ANGLE_DEGREES = 0.0;
+
+    /** Exclusive upper bound for a road angle in degrees. */
+    public static final double MAX_ANGLE_DEGREES_EXCLUSIVE = 360.0;
+
+    /** Minimum number of incoming or outgoing lanes on a road. */
+    public static final int MIN_LANES = 1;
+
+    /** Minimum roads required for an intersection. */
+    public static final int MIN_ROADS = 2;
+
+    /** Maximum roads that can connect to an intersection. */
+    public static final int MAX_ROADS = 8;
+
+    /**
+     * Minimum allowed angular separation, in degrees, between two roads at an
+     * intersection.
+     */
+    public static final double MIN_ANGLE_BETWEEN_ROADS = 30.0;
+
+    private ValidationConstants() {
+        // Utility class: prevent instantiation.
+    }
+}

--- a/src/main/java/com/trafficlightsimulator/model/Intersection.java
+++ b/src/main/java/com/trafficlightsimulator/model/Intersection.java
@@ -1,6 +1,6 @@
 package com.trafficlightsimulator.model;
 
-import com.trafficlightsimulator.config.IntersectionLimits;
+import com.trafficlightsimulator.config.ValidationConstants;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +31,7 @@ public class Intersection {
      * Minimum allowed angular separation, in degrees, between any two roads
      * connected to this intersection.
      */
-    public static final double MIN_ANGLE_BETWEEN_ROADS = IntersectionLimits.MIN_ANGLE_BETWEEN_ROADS;
+    public static final double MIN_ANGLE_BETWEEN_ROADS = ValidationConstants.MIN_ANGLE_BETWEEN_ROADS;
 
     private int numberOfRoads;
     private final List<Road> roads;
@@ -40,8 +40,8 @@ public class Intersection {
      * Creates an intersection with the given road capacity.
      *
      * @param numberOfRoads expected number of roads; must be between
-     *                      {@link IntersectionLimits#MIN_ROADS} and
-     *                      {@link IntersectionLimits#MAX_ROADS} inclusive
+     *                      {@link ValidationConstants#MIN_ROADS} and
+     *                      {@link ValidationConstants#MAX_ROADS} inclusive
      * @throws IllegalArgumentException if {@code numberOfRoads} is out of range
      */
     public Intersection(int numberOfRoads) {
@@ -56,15 +56,15 @@ public class Intersection {
      * and must remain within the allowed range.
      *
      * @param numberOfRoads new capacity; must be between
-     *                      {@link IntersectionLimits#MIN_ROADS} and
-     *                      {@link IntersectionLimits#MAX_ROADS} inclusive, and
+     *                      {@link ValidationConstants#MIN_ROADS} and
+     *                      {@link ValidationConstants#MAX_ROADS} inclusive, and
      *                      must not be less than the roads already added
      * @throws IllegalArgumentException if the value is out of range or would
      *                                  shrink below the current road count
      */
     public void setNumberOfRoads(int numberOfRoads) {
-        if (numberOfRoads < IntersectionLimits.MIN_ROADS || numberOfRoads > IntersectionLimits.MAX_ROADS) {
-            throw new IllegalArgumentException("Number of roads must be between " + IntersectionLimits.MIN_ROADS + " and " + IntersectionLimits.MAX_ROADS);
+        if (numberOfRoads < ValidationConstants.MIN_ROADS || numberOfRoads > ValidationConstants.MAX_ROADS) {
+            throw new IllegalArgumentException("Number of roads must be between " + ValidationConstants.MIN_ROADS + " and " + ValidationConstants.MAX_ROADS);
         }
         if (roads != null && numberOfRoads < roads.size()) {
             throw new IllegalArgumentException(
@@ -290,7 +290,7 @@ public class Intersection {
 
     private double calculateShortestAngleDifference(double firstAngle, double secondAngle) {
         double absoluteDifference = Math.abs(firstAngle - secondAngle);
-        return Math.min(absoluteDifference, 360.0 - absoluteDifference);
+        return Math.min(absoluteDifference, ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE - absoluteDifference);
     }
 
     private TrafficLightGroup findTrafficLightGroup(TrafficLight light) {

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -1,6 +1,6 @@
 package com.trafficlightsimulator.model;
 
-import com.trafficlightsimulator.config.RoadLimits;
+import com.trafficlightsimulator.config.ValidationConstants;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,12 +44,12 @@ public class Road {
      *
      * @param angle            road angle in degrees, measured clockwise from
      *                         north; must be in
-     *                         [{@link RoadLimits#MIN_ANGLE_DEGREES},
-     *                         {@link RoadLimits#MAX_ANGLE_DEGREES_EXCLUSIVE})
+     *                         [{@link ValidationConstants#MIN_ANGLE_DEGREES},
+     *                         {@link ValidationConstants#MAX_ANGLE_DEGREES_EXCLUSIVE})
      * @param numIncomingLanes number of incoming lanes; must be at least
-     *                         {@link RoadLimits#MIN_LANES}
+     *                         {@link ValidationConstants#MIN_LANES}
      * @param numOutgoingLanes number of outgoing lanes; must be at least
-     *                         {@link RoadLimits#MIN_LANES}
+     *                         {@link ValidationConstants#MIN_LANES}
      * @throws IllegalArgumentException if any argument is out of range
      */
     public Road(double angle, int numIncomingLanes, int numOutgoingLanes) {
@@ -67,8 +67,8 @@ public class Road {
      * Sets the road angle.
      *
      * @param angle angle in degrees; must be in
-     *              [{@link RoadLimits#MIN_ANGLE_DEGREES},
-     *              {@link RoadLimits#MAX_ANGLE_DEGREES_EXCLUSIVE})
+     *              [{@link ValidationConstants#MIN_ANGLE_DEGREES},
+     *              {@link ValidationConstants#MAX_ANGLE_DEGREES_EXCLUSIVE})
      * @throws IllegalArgumentException if the angle is out of range or would
      *                                  violate the minimum road-angle spacing
      *                                  required by the owning intersection
@@ -85,8 +85,8 @@ public class Road {
     /**
      * Returns the road angle in degrees.
      *
-     * @return angle in [{@link RoadLimits#MIN_ANGLE_DEGREES},
-     *         {@link RoadLimits#MAX_ANGLE_DEGREES_EXCLUSIVE})
+     * @return angle in [{@link ValidationConstants#MIN_ANGLE_DEGREES},
+     *         {@link ValidationConstants#MAX_ANGLE_DEGREES_EXCLUSIVE})
      */
     public double getAngle() {
         return angle;
@@ -97,12 +97,12 @@ public class Road {
      * {@link Lane} instances as needed.
      *
      * @param numIncomingLanes desired lane count; must be at least
-     *                         {@link RoadLimits#MIN_LANES}
+     *                         {@link ValidationConstants#MIN_LANES}
      * @throws IllegalArgumentException if the count is less than the minimum
      */
     public void setNumIncomingLanes(int numIncomingLanes) {
-        if (numIncomingLanes < RoadLimits.MIN_LANES) {
-            throw new IllegalArgumentException("Number of incoming lanes must be at least 1.");
+        if (numIncomingLanes < ValidationConstants.MIN_LANES) {
+            throw new IllegalArgumentException("Number of incoming lanes must be at least " + ValidationConstants.MIN_LANES + ".");
         }
         int current = this.incomingLanes.size();
         if (numIncomingLanes > current) {
@@ -130,12 +130,12 @@ public class Road {
      * {@link Lane} instances as needed.
      *
      * @param numOutgoingLanes desired lane count; must be at least
-     *                         {@link RoadLimits#MIN_LANES}
+     *                         {@link ValidationConstants#MIN_LANES}
      * @throws IllegalArgumentException if the count is less than the minimum
      */
     public void setNumOutgoingLanes(int numOutgoingLanes) {
-        if (numOutgoingLanes < RoadLimits.MIN_LANES) {
-            throw new IllegalArgumentException("Number of outgoing lanes must be at least 1.");
+        if (numOutgoingLanes < ValidationConstants.MIN_LANES) {
+            throw new IllegalArgumentException("Number of outgoing lanes must be at least " + ValidationConstants.MIN_LANES + ".");
         }
         int current = this.outgoingLanes.size();
         if (numOutgoingLanes > current) {
@@ -396,8 +396,9 @@ public class Road {
     }
 
     private void validateAngleRange(double angle) {
-        if (angle < RoadLimits.MIN_ANGLE_DEGREES || angle >= RoadLimits.MAX_ANGLE_DEGREES_EXCLUSIVE) {
-            throw new IllegalArgumentException("Angle must be between 0 and 360 degrees.");
+        if (angle < ValidationConstants.MIN_ANGLE_DEGREES || angle >= ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE) {
+            throw new IllegalArgumentException("Angle must be between " + ValidationConstants.MIN_ANGLE_DEGREES
+                    + " and " + ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE + " degrees.");
         }
     }
 

--- a/src/main/java/com/trafficlightsimulator/model/Road.java
+++ b/src/main/java/com/trafficlightsimulator/model/Road.java
@@ -368,6 +368,18 @@ public class Road {
     }
 
     /**
+     * Returns {@code true} if this road is already attached to an intersection.
+     *
+     * <p>This is primarily useful for builders and factories that need to
+     * validate a complete object graph before mutating road ownership.
+     *
+     * @return {@code true} if an intersection currently owns this road
+     */
+    public boolean isConnectedToIntersection() {
+        return intersection != null;
+    }
+
+    /**
      * Logs the lane counts and pedestrian crossing presence for diagnostic
      * purposes.
      */

--- a/src/test/java/com/trafficlightsimulator/config/IntersectionBuilderTest.java
+++ b/src/test/java/com/trafficlightsimulator/config/IntersectionBuilderTest.java
@@ -71,4 +71,52 @@ class IntersectionBuilderTest {
 
         assertTrue(exception.getMessage().contains("at least " + ValidationConstants.MIN_ANGLE_BETWEEN_ROADS));
     }
+
+    @Test
+    void build_enforcesIntersectionAngleValidationWithoutAttachingEarlierRoads() {
+        Road first = RoadBuilder.atAngle(0.0).build();
+        Road tooClose = RoadBuilder.atAngle(ValidationConstants.MIN_ANGLE_BETWEEN_ROADS - 1.0).build();
+        IntersectionBuilder invalidBuilder = IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(first)
+                .addRoad(tooClose);
+
+        assertThrows(IllegalArgumentException.class, invalidBuilder::build);
+
+        Road validReplacement = RoadBuilder.atAngle(90.0).build();
+
+        Intersection intersection = IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(first)
+                .addRoad(validReplacement)
+                .build();
+
+        assertSame(first, intersection.getRoads().get(0));
+        assertSame(validReplacement, intersection.getRoads().get(1));
+        assertTrue(intersection.isIntersectionSetupComplete());
+    }
+
+    @Test
+    void build_rejectsAlreadyAttachedRoadWithoutAttachingEarlierRoads() {
+        Road first = RoadBuilder.atAngle(0.0).build();
+        Road alreadyAttached = RoadBuilder.atAngle(90.0).build();
+        Road attachedPartner = RoadBuilder.atAngle(180.0).build();
+        IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(alreadyAttached)
+                .addRoad(attachedPartner)
+                .build();
+        IntersectionBuilder invalidBuilder = IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(first)
+                .addRoad(alreadyAttached);
+
+        assertThrows(IllegalArgumentException.class, invalidBuilder::build);
+
+        Road validReplacement = RoadBuilder.atAngle(270.0).build();
+
+        Intersection intersection = IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(first)
+                .addRoad(validReplacement)
+                .build();
+
+        assertSame(first, intersection.getRoads().get(0));
+        assertSame(validReplacement, intersection.getRoads().get(1));
+    }
 }

--- a/src/test/java/com/trafficlightsimulator/config/IntersectionBuilderTest.java
+++ b/src/test/java/com/trafficlightsimulator/config/IntersectionBuilderTest.java
@@ -1,0 +1,74 @@
+package com.trafficlightsimulator.config;
+
+import com.trafficlightsimulator.model.Intersection;
+import com.trafficlightsimulator.model.Road;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IntersectionBuilderTest {
+
+    @Test
+    void build_createsIntersectionWithConfiguredRoads() {
+        Road north = RoadBuilder.atAngle(0.0).build();
+        Road east = RoadBuilder.atAngle(90.0).lanes(2, 2).build();
+
+        Intersection intersection = IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(north)
+                .addRoad(east)
+                .build();
+
+        assertEquals(2, intersection.getRoads().size());
+        assertSame(north, intersection.getRoads().get(0));
+        assertSame(east, intersection.getRoads().get(1));
+        assertTrue(intersection.isIntersectionSetupComplete());
+    }
+
+    @Test
+    void build_infersCapacityFromRoadCountWhenCapacityIsNotConfigured() {
+        Road north = RoadBuilder.atAngle(0.0).build();
+        Road east = RoadBuilder.atAngle(90.0).build();
+
+        Intersection intersection = IntersectionBuilder.intersection()
+                .addRoad(north)
+                .addRoad(east)
+                .build();
+
+        assertEquals(2, intersection.getRoads().size());
+        assertTrue(intersection.isIntersectionSetupComplete());
+    }
+
+    @Test
+    void roadCapacity_rejectsValuesOutsideSharedBounds() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> IntersectionBuilder.withRoadCapacity(ValidationConstants.MIN_ROADS - 1));
+
+        assertTrue(exception.getMessage().contains(String.valueOf(ValidationConstants.MIN_ROADS)));
+    }
+
+    @Test
+    void addRoad_rejectsNullAndDuplicateRoads() {
+        Road road = RoadBuilder.atAngle(0.0).build();
+        IntersectionBuilder builder = IntersectionBuilder.withRoadCapacity(2).addRoad(road);
+
+        assertThrows(IllegalArgumentException.class, () -> builder.addRoad(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.addRoad(road));
+    }
+
+    @Test
+    void build_enforcesIntersectionAngleValidation() {
+        Road first = RoadBuilder.atAngle(0.0).build();
+        Road tooClose = RoadBuilder.atAngle(ValidationConstants.MIN_ANGLE_BETWEEN_ROADS - 1.0).build();
+
+        IntersectionBuilder builder = IntersectionBuilder.withRoadCapacity(2)
+                .addRoad(first)
+                .addRoad(tooClose);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+        assertTrue(exception.getMessage().contains("at least " + ValidationConstants.MIN_ANGLE_BETWEEN_ROADS));
+    }
+}

--- a/src/test/java/com/trafficlightsimulator/config/RoadBuilderTest.java
+++ b/src/test/java/com/trafficlightsimulator/config/RoadBuilderTest.java
@@ -36,16 +36,20 @@ class RoadBuilderTest {
 
     @Test
     void angle_rejectsOutOfRangeValuesBeforeBuild() {
+        RoadBuilder builder = RoadBuilder.road();
+
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> RoadBuilder.road().angle(ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE));
+                () -> builder.angle(ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE));
 
         assertTrue(exception.getMessage().contains("Angle must be between"));
     }
 
     @Test
     void incomingLanes_rejectsCountsBelowSharedMinimum() {
+        RoadBuilder builder = RoadBuilder.road();
+
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> RoadBuilder.road().incomingLanes(ValidationConstants.MIN_LANES - 1));
+                () -> builder.incomingLanes(ValidationConstants.MIN_LANES - 1));
 
         assertTrue(exception.getMessage().contains(String.valueOf(ValidationConstants.MIN_LANES)));
     }

--- a/src/test/java/com/trafficlightsimulator/config/RoadBuilderTest.java
+++ b/src/test/java/com/trafficlightsimulator/config/RoadBuilderTest.java
@@ -1,0 +1,60 @@
+package com.trafficlightsimulator.config;
+
+import com.trafficlightsimulator.model.Color;
+import com.trafficlightsimulator.model.Direction;
+import com.trafficlightsimulator.model.PedestrianCrossing;
+import com.trafficlightsimulator.model.Road;
+import com.trafficlightsimulator.model.State;
+import com.trafficlightsimulator.model.TrafficLight;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoadBuilderTest {
+
+    @Test
+    void build_createsRoadWithConfiguredGeometryAndOptionalComponents() {
+        PedestrianCrossing crossing = new PedestrianCrossing();
+        TrafficLight light = new TrafficLight(Color.GREEN, State.ON, TrafficLight.Type.TRAFFIC,
+                Direction.STRAIGHT, true);
+
+        Road road = RoadBuilder.atAngle(90.0)
+                .lanes(2, 3)
+                .pedestrianCrossing(crossing)
+                .addIncomingTrafficLight(light)
+                .build();
+
+        assertEquals(90.0, road.getAngle());
+        assertEquals(2, road.getIncomingLanes().size());
+        assertEquals(3, road.getOutgoingLanes().size());
+        assertSame(crossing, road.getPedestrianCrossing());
+        assertTrue(road.getIncomingLanesTrafficLightGroup().getLights().contains(light));
+    }
+
+    @Test
+    void angle_rejectsOutOfRangeValuesBeforeBuild() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> RoadBuilder.road().angle(ValidationConstants.MAX_ANGLE_DEGREES_EXCLUSIVE));
+
+        assertTrue(exception.getMessage().contains("Angle must be between"));
+    }
+
+    @Test
+    void incomingLanes_rejectsCountsBelowSharedMinimum() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> RoadBuilder.road().incomingLanes(ValidationConstants.MIN_LANES - 1));
+
+        assertTrue(exception.getMessage().contains(String.valueOf(ValidationConstants.MIN_LANES)));
+    }
+
+    @Test
+    void optionalComponentsRejectNulls() {
+        RoadBuilder builder = RoadBuilder.road();
+
+        assertThrows(IllegalArgumentException.class, () -> builder.pedestrianCrossing(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.addIncomingTrafficLight(null));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide fluent builders for `Road` and `Intersection` construction to simplify validated assembly of model objects.  
- Centralize validation limits so construction-time builders and existing model mutators share a single source of truth.  
- Preserve backwards compatibility for callers that referenced the older per-type limit holders while preparing the codebase for clearer factory usage.  

### Description

- Added `ValidationConstants` as the single source for road-angle bounds, lane minimums, intersection road-count bounds, and minimum road-angle spacing.  
- Added fluent factories `RoadBuilder` and `IntersectionBuilder` under `com.trafficlightsimulator.config` with validation, optional pedestrian-crossing and incoming-light attachment, capacity inference, duplicate/null guards, and build-time intersection validation.  
- Updated `Road` and `Intersection` to reference `ValidationConstants` for validation and error messages and replaced literal/previous-constant uses accordingly.  
- Retained `RoadLimits` and `IntersectionLimits` as deprecated compatibility facades delegating to `ValidationConstants`.  
- Added unit tests for the builders (`RoadBuilderTest`, `IntersectionBuilderTest`) and updated `README.md`, `CHANGELOG.md`, and `pom.xml` (bumped to `0.15.0-SNAPSHOT`).  

### Testing

- Ran `git diff --check` and source compilation via `javac -Xlint` which completed successfully (emitted existing `this-escape` constructor warnings).  
- Attempted to run the Maven verification lifecycle (`mvn -B verify`), but the run was blocked by an external artifact resolution failure: Maven Central returned `403 Forbidden` while resolving `org.jacoco:jacoco-maven-plugin:0.8.12`, preventing test execution.  
- Confirmed the new builder tests compile and are present under `src/test/java/com/trafficlightsimulator/config/` but could not execute them in this environment due to the plugin download failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22480f7ef48325848bcfa2cabc34ef)