### PR TITLE
chore: add repository governance templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a reproducible problem in the simulator or repository workflow
+title: "bug: "
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+Briefly describe the problem.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What should happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Java version:
+- Maven version:
+- Operating system:
+- Repository version or commit:
+
+## Logs or screenshots
+
+Paste relevant logs, stack traces, or screenshots. Please remove secrets or personal data.
+
+## Additional context
+
+Add any other details that may help with diagnosis.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,33 @@
+---
+name: Enhancement request
+about: Suggest an improvement to the simulator, documentation, or repository workflow
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+Briefly describe the requested improvement.
+
+## Motivation
+
+What problem does this solve, or what workflow does it improve?
+
+## Proposed solution
+
+Describe the behavior, API, documentation, or workflow change you would like.
+
+## Alternatives considered
+
+List any alternative approaches you considered.
+
+## Compatibility and versioning impact
+
+- [ ] No user-facing behavior change expected.
+- [ ] Backward-compatible feature or documentation/workflow improvement.
+- [ ] Potential breaking change; SemVer impact should be discussed.
+
+## Additional context
+
+Add references, examples, diagrams, or related issues.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+- 
+
+## Related issue
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Enhancement
+- [ ] Documentation
+- [ ] CI/CD or repository maintenance
+- [ ] Breaking change
+
+## Checklist
+
+- [ ] I ran `mvn -B verify` locally or documented why it could not be run.
+- [ ] I updated `CHANGELOG.md` for user-visible, repository-governance, or workflow changes.
+- [ ] I updated README/component documentation when behavior or contributor workflow changed.
+- [ ] I considered whether the pre-MVP SemVer version in `pom.xml` and README needs to change.
+- [ ] I confirmed new or changed GitHub Actions keep least-privilege permissions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ the current `0.x` baseline.
 
 ### Added
 
+- Dependabot version-update coverage for the GitHub Actions ecosystem on a
+  weekly schedule.
+- Pull request and issue templates for bug reports and enhancement requests.
+- CONTRIBUTING guidance for branch naming, Commitizen-style commits,
+  CHANGELOG/SemVer expectations, CI checks, and the recommended `main`
+  branch-protection policy.
+
+### Changed
+
+- Bumped the pre-MVP development version from `0.15.0-SNAPSHOT` to
+  `0.16.0-SNAPSHOT` for repository governance and hygiene updates.
+
+### Added
+
 - `ValidationConstants` as the single source for road-angle, lane-count,
   intersection road-count, and minimum road-angle-spacing limits.
 - Fluent `RoadBuilder` and `IntersectionBuilder` factories that enforce shared

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Traffic Light Simulator
+
+Thank you for helping improve Traffic Light Simulator. This repository is a pre-MVP Java 17 Maven project, so contributor changes should keep the codebase easy to validate and the project history easy to understand.
+
+## Before you start
+
+1. Open or find a GitHub issue that describes the change.
+2. Comment on the issue if you plan a larger change, especially one that may affect public APIs, validation behavior, CI, or release versioning.
+3. Create a focused branch from the latest `main`.
+
+## Branch naming
+
+Use short, descriptive, lowercase branch names with hyphen-separated words:
+
+- `feat/<issue-number>-short-description` for new capabilities.
+- `fix/<issue-number>-short-description` for bug fixes.
+- `docs/<issue-number>-short-description` for documentation-only updates.
+- `ci/<issue-number>-short-description` for GitHub Actions or automation changes.
+- `chore/<issue-number>-short-description` for repository maintenance.
+
+Examples:
+
+- `feat/42-pedestrian-timing-rules`
+- `ci/51-repository-governance`
+- `docs/51-contributing-guide`
+
+## Commit messages
+
+Use Commitizen-style conventional commit messages:
+
+```text
+<type>(optional-scope): <short imperative summary>
+```
+
+Common types include `feat`, `fix`, `docs`, `test`, `ci`, `chore`, and `refactor`. Reference the issue in the commit body or pull-request description when applicable.
+
+Examples:
+
+```text
+ci: add dependabot coverage for github actions
+
+docs: document contribution workflow
+```
+
+## Development setup
+
+- Install Java 17.
+- Install Maven.
+- Run commands from the repository root.
+
+Build and test the project with:
+
+```sh
+mvn -B verify
+```
+
+Generate Javadoc when API documentation changes:
+
+```sh
+mvn javadoc:javadoc
+```
+
+## Tests and CI expectations
+
+Every pull request should either pass the Maven verification lifecycle or explain why it could not be run locally. The GitHub Actions CI workflow is expected to run on pull requests and `main` pushes, using Java 17 and `mvn -B verify`.
+
+For code changes, add or update tests that cover the changed behavior. For documentation, template, or workflow-only changes, make sure the relevant Markdown/YAML files are reviewed for clarity and syntax.
+
+## CHANGELOG and SemVer expectations
+
+This project follows Semantic Versioning and is currently pre-MVP in the `0.x.y` range. Until `1.0.0`, minor releases (`0.MINOR.0`) may include breaking changes as the domain model evolves; patch releases (`0.x.PATCH`) are reserved for backward-compatible fixes within the current pre-MVP baseline.
+
+When opening a pull request:
+
+- Add a concise entry to `CHANGELOG.md` under `[Unreleased]` for user-visible code, documentation, CI, governance, or workflow changes.
+- Update the development version in `pom.xml` and README when the issue or release plan calls for a version increment.
+- Use SemVer to choose the next version. For pre-MVP feature, governance, CI, or documentation baseline changes, increment the minor version and keep the `-SNAPSHOT` qualifier during development.
+- Mention any breaking behavior or migration notes in the pull request.
+
+## Pull requests
+
+Pull requests should be small enough to review comfortably and should use the repository pull-request template. Include:
+
+- A summary of the change.
+- The related issue number.
+- Test commands and results.
+- Documentation, changelog, and versioning notes.
+- Any required maintainer follow-up or manual action.
+
+## Recommended `main` branch protection
+
+Repository administrators should protect `main` in GitHub settings. Recommended rules:
+
+- Require a pull request before merging.
+- Require at least one approving review.
+- Require status checks to pass before merging, including the CI build/test check.
+- Require branches to be up to date before merging when practical.
+- Restrict force pushes and branch deletion.
+- Require conversation resolution before merging.
+
+Applying these settings requires repository administrator access. Contributors should note in the pull request if a change depends on branch-protection updates or other maintainer-only configuration.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ until a stable `1.0.0` release is declared.
 
 - **Maven group ID:** `com.trafficlightsimulator`
 - **Maven artifact ID:** `TrafficLightSimulator`
-- **Current development version:** `0.15.0-SNAPSHOT`
+- **Current development version:** `0.16.0-SNAPSHOT`
 - **Java baseline:** Java 17
 
 ## Architecture overview
@@ -99,7 +99,7 @@ Build the executable jar package, then launch it with `java -jar`:
 
 ```sh
 mvn -B package
-java -jar target/TrafficLightSimulator-0.15.0-SNAPSHOT.jar
+java -jar target/TrafficLightSimulator-0.16.0-SNAPSHOT.jar
 ```
 
 ## Generating API documentation
@@ -139,6 +139,12 @@ To resolve it:
    mvn -U -B verify
    ```
 
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+It documents the expected branch names, Commitizen-style commit messages,
+CHANGELOG and pre-MVP SemVer updates, CI/test requirements, and the recommended
+`main` branch-protection policy.
 
 ## Fluent builders and validation constants
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trafficlightsimulator</groupId>
     <artifactId>TrafficLightSimulator</artifactId>
-    <version>0.15.0-SNAPSHOT</version>
+    <version>0.16.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <properties>


### PR DESCRIPTION
### Motivation

- Improve repository governance and contributor onboarding with clear templates, a contributing guide, and Dependabot coverage for GitHub Actions. 
- Make it easier to enforce Commitizen-style commit messages and SemVer expectations during the pre-MVP lifecycle. 
- Surface repository hygiene and CI expectations in `README.md` and `CHANGELOG.md` and bump the development snapshot version to reflect these governance changes.

### Description

- Added PR and issue templates at `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/{bug_report.md,enhancement.md}` to standardize intake and checklist items. 
- Added `CONTRIBUTING.md` with branch naming, Commitizen-style commit guidance, local verification steps, CHANGELOG/SemVer rules, PR expectations, and recommended `main` branch-protection rules. 
- Expanded Dependabot config (`.github/dependabot.yml`) to include weekly updates for the `github-actions` ecosystem and updated `CHANGELOG.md`/`README.md`. 
- Bumped pre-MVP development version from `0.15.0-SNAPSHOT` to `0.16.0-SNAPSHOT` in `pom.xml` and `README.md`; updated `CHANGELOG.md` with an unreleased entry. 
- Note: repository administrator action required to apply the recommended `main` branch-protection settings in GitHub (require PRs, approvals, passing CI checks, up-to-date branches, conversation resolution, and restrict force pushes/deletion).

### Testing

- Ran `git diff --check` and repository content checks (Python script) to validate presence and basic content of the new templates and `CONTRIBUTING.md`, which passed. 
- Confirmed staged commit created with message `chore: add repository governance templates`. 
- Attempted `mvn -B verify` but the build failed to resolve `org.jacoco:jacoco-maven-plugin:0.8.12` due to an HTTP 403 from Maven Central, which matches the repository documented Maven Central 403 symptom and is environmental rather than a code change failure. 
- No unit-test or code regressions were introduced by these documentation/CI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224d59a70483258a8f61a565acb916)